### PR TITLE
New API: uc_afl_fuzz_ext

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -145,7 +145,7 @@ setuptools.setup(
     zip_safe=False,
     include_package_data=True,
     install_requires=[
-        "unicorn>=2.0.0rc5"
+        "unicorn>=2.0.0rc6"
     ],
     is_pure=False,
     package_data={

--- a/bindings/python/unicornafl/__init__.py
+++ b/bindings/python/unicornafl/__init__.py
@@ -1,3 +1,3 @@
-from .unicornafl import uc_afl_fuzz, monkeypatch, UcAflError, UC_AFL_RET_OK, UC_AFL_RET_ERROR, UC_AFL_RET_CHILD, UC_AFL_RET_NO_AFL, UC_AFL_RET_CALLED_TWICE, UC_AFL_RET_FINISHED
+from .unicornafl import uc_afl_fuzz, uc_afl_fuzz_ext, monkeypatch, UcAflError, UC_AFL_RET_OK, UC_AFL_RET_ERROR, UC_AFL_RET_CHILD, UC_AFL_RET_NO_AFL, UC_AFL_RET_CALLED_TWICE, UC_AFL_RET_FINISHED
 # Compatibility
 from unicorn import *

--- a/bindings/python/unicornafl/__init__.py
+++ b/bindings/python/unicornafl/__init__.py
@@ -1,3 +1,3 @@
-from .unicornafl import uc_afl_fuzz, uc_afl_fuzz_ext, monkeypatch, UcAflError, UC_AFL_RET_OK, UC_AFL_RET_ERROR, UC_AFL_RET_CHILD, UC_AFL_RET_NO_AFL, UC_AFL_RET_CALLED_TWICE, UC_AFL_RET_FINISHED
+from .unicornafl import uc_afl_fuzz, uc_afl_fuzz_custom, monkeypatch, UcAflError, UC_AFL_RET_OK, UC_AFL_RET_ERROR, UC_AFL_RET_CHILD, UC_AFL_RET_NO_AFL, UC_AFL_RET_CALLED_TWICE, UC_AFL_RET_FINISHED
 # Compatibility
 from unicorn import *

--- a/bindings/python/unicornafl/unicornafl.py
+++ b/bindings/python/unicornafl/unicornafl.py
@@ -119,14 +119,14 @@ _uc2afl.uc_afl_fuzz.restype = ctypes.c_int
 _uc2afl.uc_afl_fuzz.argtypes = (ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p, ctypes.c_void_p,
                                 ctypes.c_size_t, ctypes.c_void_p, ctypes.c_bool, ctypes.c_uint32, ctypes.c_void_p)
 
-# uc_afl_ret uc_afl_fuzz_ext(uc_engine* uc, char* input_file,
+# uc_afl_ret uc_afl_fuzz_custom(uc_engine* uc, char* input_file,
 #                            uc_afl_cb_place_input_t place_input_callback,
 #                            uc_afl_fuzz_cb_t fuzz_callbck,
 #                            uc_afl_cb_validate_crash_t validate_crash_callback,
 #                            bool always_validate, uint32_t persistent_iters,
 #                            void* data)
-_uc2afl.uc_afl_fuzz_ext.restype = ctypes.c_int
-_uc2afl.uc_afl_fuzz_ext.argtypes = (ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p, ctypes.c_void_p,
+_uc2afl.uc_afl_fuzz_custom.restype = ctypes.c_int
+_uc2afl.uc_afl_fuzz_custom.argtypes = (ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p, ctypes.c_void_p,
                                     ctypes.c_void_p, ctypes.c_bool, ctypes.c_uint32, ctypes.c_void_p)
 # Is it necessary?
 _data_dict = {}
@@ -202,14 +202,14 @@ def uc_afl_fuzz(uc: Uc,
     # Really?
     return err
 
-def uc_afl_fuzz_ext(uc: Uc,
-                    input_file: str,
-                    place_input_callback: Callable,
-                    fuzzing_callback: Callable,
-                    validate_crash_callback: Callable = None,
-                    always_validate: bool = False,
-                    persistent_iters: int = 1,
-                    data: Any = None):
+def uc_afl_fuzz_custom(uc: Uc,
+                       input_file: str,
+                       place_input_callback: Callable,
+                       fuzzing_callback: Callable,
+                       validate_crash_callback: Callable = None,
+                       always_validate: bool = False,
+                       persistent_iters: int = 1,
+                       data: Any = None):
     global _data_idx, _data_dict
 
     # Someone else is fuzzing, quit!
@@ -228,7 +228,7 @@ def uc_afl_fuzz_ext(uc: Uc,
     cb3 = ctypes.cast(UC_AFL_FUZZ_CALLBACK_CB(
         _fuzz_callback_cb), UC_AFL_FUZZ_CALLBACK_CB)
 
-    err = _uc2afl.uc_afl_fuzz_ext(uc._uch, input_file.encode("utf-8"), cb1, cb3, 
+    err = _uc2afl.uc_afl_fuzz_custom(uc._uch, input_file.encode("utf-8"), cb1, cb3, 
         cb2, always_validate, persistent_iters, ctypes.cast(idx, ctypes.c_void_p))
 
     if err != UC_AFL_RET_OK:

--- a/include/unicornafl/unicornafl.h
+++ b/include/unicornafl/unicornafl.h
@@ -32,6 +32,8 @@ typedef bool (*uc_afl_cb_validate_crash_t)(uc_engine* uc, uc_err unicorn_result,
                                            char* input, int input_len,
                                            int persistent_round, void* data);
 
+typedef uc_err (*uc_afl_fuzz_cb_t)(uc_engine *uc, void *data);
+
 //
 //  Start our fuzzer.
 //
@@ -58,6 +60,21 @@ uc_afl_ret uc_afl_fuzz(uc_engine* uc, char* input_file,
                        uc_afl_cb_validate_crash_t validate_crash_callback,
                        bool always_validate, uint32_t persistent_iters,
                        void* data);
+
+//
+// By default, uc_afl_fuzz internall calls uc_emu_start only once and if uc_emu_stop
+// is called, the child will stop fuzzing current test case.
+//
+// To implement more complex fuzzing logic, pass an extra fuzzing_callback with this API.
+//
+//
+UNICORN_EXPORT
+uc_afl_ret uc_afl_fuzz_ext(uc_engine* uc, char* input_file,
+                           uc_afl_cb_place_input_t place_input_callback,
+                           uc_afl_fuzz_cb_t fuzz_callbck,
+                           uc_afl_cb_validate_crash_t validate_crash_callback,
+                           bool always_validate, uint32_t persistent_iters,
+                           void* data);
 
 #ifdef __cplusplus
 }

--- a/include/unicornafl/unicornafl.h
+++ b/include/unicornafl/unicornafl.h
@@ -67,14 +67,13 @@ uc_afl_ret uc_afl_fuzz(uc_engine* uc, char* input_file,
 //
 // To implement more complex fuzzing logic, pass an extra fuzzing_callback with this API.
 //
-//
 UNICORN_EXPORT
-uc_afl_ret uc_afl_fuzz_ext(uc_engine* uc, char* input_file,
-                           uc_afl_cb_place_input_t place_input_callback,
-                           uc_afl_fuzz_cb_t fuzz_callbck,
-                           uc_afl_cb_validate_crash_t validate_crash_callback,
-                           bool always_validate, uint32_t persistent_iters,
-                           void* data);
+uc_afl_ret uc_afl_fuzz_custom(uc_engine* uc, char* input_file,
+                              uc_afl_cb_place_input_t place_input_callback,
+                              uc_afl_fuzz_cb_t fuzz_callbck,
+                              uc_afl_cb_validate_crash_t validate_crash_callback,
+                              bool always_validate, uint32_t persistent_iters,
+                              void* data);
 
 #ifdef __cplusplus
 }

--- a/include/unicornafl/unicornafl.h
+++ b/include/unicornafl/unicornafl.h
@@ -13,7 +13,7 @@ extern "C" {
 #define UNICORNAFL_EXPORT
 #endif
 
-#define MIN_UC_VERSION 0x02000005
+#define MIN_UC_VERSION 0x02000006
 
 typedef enum uc_afl_ret {
     UC_AFL_RET_OK = 0,

--- a/unicornafl.cpp
+++ b/unicornafl.cpp
@@ -87,8 +87,8 @@ static void log(bool in_child, const char* fmt, ...) {
 #define ERR_CHILD(...)
 #endif
 
-static uc_err dummy_uc_afl_fuzz_callback(uc_engine *uc, void *data);
-static uint64_t uc_get_pc(uc_engine *uc);
+static uc_err dummy_uc_afl_fuzz_callback(uc_engine* uc, void* data);
+static uint64_t uc_get_pc(uc_engine* uc);
 
 class UCAFL {
 
@@ -96,13 +96,12 @@ class UCAFL {
     UCAFL(uc_engine* uc, const char* input_file,
           uc_afl_cb_place_input_t place_input_callback,
           uc_afl_cb_validate_crash_t validate_crash_callback,
-          uc_afl_fuzz_cb_t fuzz_callback,
-          bool always_validate, uint32_t persistent_iters, void* data)
+          uc_afl_fuzz_cb_t fuzz_callback, bool always_validate,
+          uint32_t persistent_iters, void* data)
         : uc_(uc), input_file_(input_file),
           place_input_callback_(place_input_callback),
           validate_crash_callback_(validate_crash_callback),
-          fuzz_callback_(fuzz_callback),
-          always_validate_(always_validate),
+          fuzz_callback_(fuzz_callback), always_validate_(always_validate),
           persistent_iters_(persistent_iters), data_(data),
           afl_testcase_ptr_(nullptr), afl_testcase_len_p_(nullptr),
           afl_area_ptr_(nullptr), has_afl_(false), afl_prev_loc_(0), h1_(0),
@@ -877,16 +876,16 @@ class UCAFL {
     uc_hook h4_;
 };
 
-static uc_err dummy_uc_afl_fuzz_callback(uc_engine *uc, void *data) {
+static uc_err dummy_uc_afl_fuzz_callback(uc_engine* uc, void* data) {
     uint64_t pc;
 
     pc = uc_get_pc(uc);
 
     // Note the multiple exits is enabled in this case.
-    return uc_emu_start(uc, pc, 0, 0 ,0);
+    return uc_emu_start(uc, pc, 0, 0, 0);
 }
 
-static uint64_t uc_get_pc(uc_engine *uc) {
+static uint64_t uc_get_pc(uc_engine* uc) {
     uc_arch arch;
     uc_mode mode;
     uint64_t pc = 0;
@@ -963,8 +962,9 @@ extern "C" UNICORNAFL_EXPORT uc_afl_ret uc_afl_fuzz(
         return UC_AFL_RET_ERROR;
     }
 
-    UCAFL ucafl(uc, input_file, place_input_callback, validate_crash_callback, dummy_uc_afl_fuzz_callback,
-                always_validate, persistent_iters, data);
+    UCAFL ucafl(uc, input_file, place_input_callback, validate_crash_callback,
+                dummy_uc_afl_fuzz_callback, always_validate, persistent_iters,
+                data);
 
     if (unlikely(ucafl.set_exits(exits, exit_count))) {
         return UC_AFL_RET_ERROR;
@@ -978,7 +978,7 @@ extern "C" UNICORNAFL_EXPORT uc_afl_ret uc_afl_fuzz_ext(
     uc_afl_cb_place_input_t place_input_callback, uc_afl_fuzz_cb_t fuzz_callbck,
     uc_afl_cb_validate_crash_t validate_crash_callback, bool always_validate,
     uint32_t persistent_iters, void* data) {
-    
+
     log_init();
 
     if (!uc) {
@@ -1002,8 +1002,8 @@ extern "C" UNICORNAFL_EXPORT uc_afl_ret uc_afl_fuzz_ext(
         return UC_AFL_RET_ERROR;
     }
 
-    UCAFL ucafl(uc, input_file, place_input_callback, validate_crash_callback, fuzz_callbck,
-                always_validate, persistent_iters, data);
+    UCAFL ucafl(uc, input_file, place_input_callback, validate_crash_callback,
+                fuzz_callbck, always_validate, persistent_iters, data);
 
     return ucafl.fsrv_run();
 }

--- a/unicornafl.cpp
+++ b/unicornafl.cpp
@@ -973,7 +973,7 @@ extern "C" UNICORNAFL_EXPORT uc_afl_ret uc_afl_fuzz(
     return ucafl.fsrv_run();
 }
 
-extern "C" UNICORNAFL_EXPORT uc_afl_ret uc_afl_fuzz_ext(
+extern "C" UNICORNAFL_EXPORT uc_afl_ret uc_afl_fuzz_custom(
     uc_engine* uc, char* input_file,
     uc_afl_cb_place_input_t place_input_callback, uc_afl_fuzz_cb_t fuzz_callbck,
     uc_afl_cb_validate_crash_t validate_crash_callback, bool always_validate,

--- a/unicornafl.cpp
+++ b/unicornafl.cpp
@@ -87,16 +87,21 @@ static void log(bool in_child, const char* fmt, ...) {
 #define ERR_CHILD(...)
 #endif
 
+static uc_err dummy_uc_afl_fuzz_callback(uc_engine *uc, void *data);
+static uint64_t uc_get_pc(uc_engine *uc);
+
 class UCAFL {
 
   public:
     UCAFL(uc_engine* uc, const char* input_file,
           uc_afl_cb_place_input_t place_input_callback,
           uc_afl_cb_validate_crash_t validate_crash_callback,
+          uc_afl_fuzz_cb_t fuzz_callback,
           bool always_validate, uint32_t persistent_iters, void* data)
         : uc_(uc), input_file_(input_file),
           place_input_callback_(place_input_callback),
           validate_crash_callback_(validate_crash_callback),
+          fuzz_callback_(fuzz_callback),
           always_validate_(always_validate),
           persistent_iters_(persistent_iters), data_(data),
           afl_testcase_ptr_(nullptr), afl_testcase_len_p_(nullptr),
@@ -245,48 +250,6 @@ class UCAFL {
         UCAFL* ucafl_;
     };
 
-    uint64_t _get_pc() {
-        uc_arch arch;
-        uc_mode mode;
-        uint64_t pc = 0;
-
-        uc_ctl_get_arch(this->uc_, &arch);
-        uc_ctl_get_mode(this->uc_, &mode);
-
-        if (arch == UC_ARCH_X86) {
-            if (mode == UC_MODE_32) {
-                uc_reg_read(this->uc_, UC_X86_REG_EIP, &pc);
-            } else if (mode == UC_MODE_16) {
-                uc_reg_read(this->uc_, UC_X86_REG_IP, &pc);
-            } else {
-                uc_reg_read(this->uc_, UC_X86_REG_RIP, &pc);
-            }
-        } else if (arch == UC_ARCH_ARM) {
-            uint64_t cpsr = 0;
-            uc_reg_read(this->uc_, UC_ARM_REG_PC, &pc);
-
-            // check for thumb mode
-            uc_reg_read(this->uc_, UC_ARM_REG_CPSR, &cpsr);
-            if (cpsr & 0x20) {
-                // thumb mode, the address should end with 1
-                pc |= 1;
-            }
-
-        } else if (arch == UC_ARCH_RISCV) {
-            uc_reg_read(this->uc_, UC_RISCV_REG_PC, &pc);
-        } else if (arch == UC_ARCH_MIPS) {
-            uc_reg_read(this->uc_, UC_MIPS_REG_PC, &pc);
-        } else if (arch == UC_ARCH_PPC) {
-            uc_reg_read(this->uc_, UC_PPC_REG_PC, &pc);
-        } else if (arch == UC_ARCH_SPARC) {
-            uc_reg_read(this->uc_, UC_SPARC_REG_PC, &pc);
-        } else if (arch == UC_ARCH_M68K) {
-            uc_reg_read(this->uc_, UC_M68K_REG_PC, &pc);
-        }
-
-        return pc;
-    }
-
     uc_afl_ret _child_fuzz(bool afl_exist) {
         bool crash_found = false;
         bool first_round = true;
@@ -315,14 +278,7 @@ class UCAFL {
                 continue;
             }
 
-            // (Lazymio): maybe we cant get rid of this small overhead in the
-            // future?
-            uint64_t pc = this->_get_pc();
-
-            ERR_CHILD("We are starting from 0x%" PRIx64 "\n", pc);
-
-            // Note we have enabled exits.
-            uc_err uc_ret = uc_emu_start(this->uc_, pc, 0, 0, 0);
+            uc_err uc_ret = this->fuzz_callback_(this->uc_, this->data_);
 
             ERR_CHILD("We are stopping for uc_err=%d (%s)\n", uc_ret,
                       uc_strerror(uc_ret));
@@ -890,6 +846,7 @@ class UCAFL {
     const char* input_file_;
     uc_afl_cb_place_input_t place_input_callback_;
     uc_afl_cb_validate_crash_t validate_crash_callback_;
+    uc_afl_fuzz_cb_t fuzz_callback_;
     bool always_validate_;
     uint32_t persistent_iters_;
     void* data_;
@@ -919,6 +876,59 @@ class UCAFL {
     uc_hook h3_;
     uc_hook h4_;
 };
+
+static uc_err dummy_uc_afl_fuzz_callback(uc_engine *uc, void *data) {
+    uint64_t pc;
+
+    pc = uc_get_pc(uc);
+
+    // Note the multiple exits is enabled in this case.
+    return uc_emu_start(uc, pc, 0, 0 ,0);
+}
+
+static uint64_t uc_get_pc(uc_engine *uc) {
+    uc_arch arch;
+    uc_mode mode;
+    uint64_t pc = 0;
+
+    uc_ctl_get_arch(uc, &arch);
+    uc_ctl_get_mode(uc, &mode);
+
+    if (arch == UC_ARCH_X86) {
+        if (mode == UC_MODE_32) {
+            uc_reg_read(uc, UC_X86_REG_EIP, &pc);
+        } else if (mode == UC_MODE_16) {
+            uc_reg_read(uc, UC_X86_REG_IP, &pc);
+        } else {
+            uc_reg_read(uc, UC_X86_REG_RIP, &pc);
+        }
+    } else if (arch == UC_ARCH_ARM) {
+        uint64_t cpsr = 0;
+        uc_reg_read(uc, UC_ARM_REG_PC, &pc);
+
+        // check for thumb mode
+        uc_reg_read(uc, UC_ARM_REG_CPSR, &cpsr);
+        if (cpsr & 0x20) {
+            // thumb mode, the address should end with 1
+            pc |= 1;
+        }
+
+    } else if (arch == UC_ARCH_RISCV) {
+        uc_reg_read(uc, UC_RISCV_REG_PC, &pc);
+    } else if (arch == UC_ARCH_MIPS) {
+        uc_reg_read(uc, UC_MIPS_REG_PC, &pc);
+    } else if (arch == UC_ARCH_PPC) {
+        uc_reg_read(uc, UC_PPC_REG_PC, &pc);
+    } else if (arch == UC_ARCH_SPARC) {
+        uc_reg_read(uc, UC_SPARC_REG_PC, &pc);
+    } else if (arch == UC_ARCH_M68K) {
+        uc_reg_read(uc, UC_M68K_REG_PC, &pc);
+    } else if (arch == UC_ARCH_S390X) {
+        uc_reg_read(uc, UC_S390X_REG_PC, &pc);
+    }
+
+    return pc;
+}
 
 extern "C" UNICORNAFL_EXPORT uc_afl_ret uc_afl_fuzz(
     uc_engine* uc, char* input_file,
@@ -953,12 +963,47 @@ extern "C" UNICORNAFL_EXPORT uc_afl_ret uc_afl_fuzz(
         return UC_AFL_RET_ERROR;
     }
 
-    UCAFL ucafl(uc, input_file, place_input_callback, validate_crash_callback,
+    UCAFL ucafl(uc, input_file, place_input_callback, validate_crash_callback, dummy_uc_afl_fuzz_callback,
                 always_validate, persistent_iters, data);
 
     if (unlikely(ucafl.set_exits(exits, exit_count))) {
         return UC_AFL_RET_ERROR;
     }
+
+    return ucafl.fsrv_run();
+}
+
+extern "C" UNICORNAFL_EXPORT uc_afl_ret uc_afl_fuzz_ext(
+    uc_engine* uc, char* input_file,
+    uc_afl_cb_place_input_t place_input_callback, uc_afl_fuzz_cb_t fuzz_callbck,
+    uc_afl_cb_validate_crash_t validate_crash_callback, bool always_validate,
+    uint32_t persistent_iters, void* data) {
+    
+    log_init();
+
+    if (!uc) {
+        ERR("Unicorn Engine passed to uc_afl_fuzz is NULL!\n");
+        return UC_AFL_RET_ERROR;
+    }
+    if (!input_file || input_file[0] == 0) {
+        ERR("No input file provided to uc_afl_fuzz.\n");
+        return UC_AFL_RET_ERROR;
+    }
+    if (!place_input_callback) {
+        ERR("no place_input_callback set.\n");
+        return UC_AFL_RET_ERROR;
+    }
+    if (always_validate && !validate_crash_callback) {
+        ERR("always_validate set but validate_crash_callback is missing.\n");
+        return UC_AFL_RET_ERROR;
+    }
+    if (!fuzz_callbck) {
+        ERR("No fuzz_callback set.\n");
+        return UC_AFL_RET_ERROR;
+    }
+
+    UCAFL ucafl(uc, input_file, place_input_callback, validate_crash_callback, fuzz_callbck,
+                always_validate, persistent_iters, data);
 
     return ucafl.fsrv_run();
 }


### PR DESCRIPTION
The original API `uc_afl_fuzz` assumes that once the emulation stops, then AFL would check if the result infers a crash. However, it might be the case that, the emulation is stopped by design to implement some complex logic like timeclock interrupts and thus `uc_afl_fuzz_ext` serves as an advanced API for users.

This also bumps unicorn version to rc6.