### PR TITLE
Prevent recompiling unicornafl every build (#2)

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -15,7 +15,6 @@ fn add_lib(path: &str, name: &str) {
 }
 
 fn main() {
-    println!("cargo:rerun-if-changed=unicornafl");
     println!("cargo:rerun-if-changed=src");
     println!("cargo:rerun-if-changed=../../include");
     println!("cargo:rerun-if-changed=../../unicornafl.cpp");


### PR DESCRIPTION
When unicornafl is used as a Rust dependency, cargo recompiles it every build regardless of whether anything has changed.

```
$ CARGO_LOG=cargo::core::compiler::fingerprint=info cargo run
[2022-06-08T21:39:09Z INFO  cargo::core::compiler::fingerprint] stale: missing "/mnt/c/Users/starfleetcadet75/Projects/unicornafl/bindings/rust/unicornafl"
[2022-06-08T21:39:09Z INFO  cargo::core::compiler::fingerprint] fingerprint error for fuzzer v0.1.0 (/mnt/c/Users/starfleetcadet75/Projects/fuzzer)/Build/TargetInner { name: "fuzzer", doc: true, ..: with_path("/mnt/c/Users/starfleetcadet75/Projects/fuzzer/src/main.rs", Edition2021) }
[2022-06-08T21:39:09Z INFO  cargo::core::compiler::fingerprint]     err: current filesystem status shows we're outdated
[2022-06-08T21:39:09Z INFO  cargo::core::compiler::fingerprint] fingerprint error for unicornafl v1.1.0 (/mnt/c/Users/starfleetcadet75/Projects/unicornafl/bindings/rust)/Build/TargetInner { ..: lib_target("unicornafl", ["lib"], "/mnt/c/Users/starfleetcadet75/Projects/unicornafl/bindings/rust/src/lib.rs", Edition2018) }
[2022-06-08T21:39:09Z INFO  cargo::core::compiler::fingerprint]     err: current filesystem status shows we're outdated
[2022-06-08T21:39:09Z INFO  cargo::core::compiler::fingerprint] fingerprint error for unicornafl v1.1.0 (/mnt/c/Users/starfleetcadet75/Projects/unicornafl/bindings/rust)/RunCustomBuild/TargetInner { ..: custom_build_target("build-script-build", "/mnt/c/Users/starfleetcadet75/Projects/unicornafl/bindings/rust/build.rs", Edition2018) }
[2022-06-08T21:39:09Z INFO  cargo::core::compiler::fingerprint]     err: current filesystem status shows we're outdated
   Compiling unicornafl v1.1.0 (/mnt/c/Users/starfleetcadet75/Projects/unicornafl/bindings/rust)
    Building [=====================>     ] 16/19: unicornafl(build)
```

The file "./unicornafl/bindings/rust/unicornafl" seems to never actually exist. Line 18 in the build.rs file checks for this path to trigger the recompilation. Since it never exists in the first place, unicornafl is forced to rebuild everytime.