### PR TITLE
add linking to tricore

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -52,6 +52,7 @@ fn main() {
         "ppc",
         "ppc64",
         "s390x",
+        "tricore",
     ]
     .iter()
     {


### PR DESCRIPTION
Hi, I tried to compile the speedtest Rust sample and faced the following compilation error.
```
error: linking with `cc` failed: exit status: 1
  = note: /usr/bin/ld: /tmp/rustcnLbAXp/libunicornafl-8a7c88d0fe9f2649.rlib(uc.c.o): in function `uc_open':
          uc.c:(.text+0xd33): undefined reference to `tricore_uc_init'
          /usr/bin/ld: /tmp/rustcnLbAXp/libunicornafl-8a7c88d0fe9f2649.rlib(uc.c.o): in function `find_context_reg_rw_function':
          uc.c:(.text+0x4283): undefined reference to `tricore_context_reg_read'
          /usr/bin/ld: uc.c:(.text+0x4291): undefined reference to `tricore_context_reg_write'
          collect2: error: ld returned 1 exit status
```
Adding this line to the build.rs fixed the issue.
