### PR TITLE
Introduce AFL_DEBUG_UNICORN and document logging

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -96,3 +96,10 @@ import unicornafl
 
 unicornafl.uc_afl_fuzz(uc, ...)
 ```
+
+## Debugging
+
+UnicornAFL supports debugging in a similar way to AFL++.
+Setting the environment variable `AFL_DEBUG` will provide additional output relating to the forkserver and interaction between parent and child processes during execution.
+As usual with AFL++, `AFL_DEBUG_CHILD` will enable the output of the fuzzed children.
+This output can be further enriched via the `AFL_DEBUG_UNICORN` variable, which will detail information about child execution including block translations, hooks, and encountered errors. Note that this variable also requires `AFL_DEBUG_CHILD` to be set, as the output is provided from child context.

--- a/unicornafl.cpp
+++ b/unicornafl.cpp
@@ -23,7 +23,7 @@
 #include <cstdlib>
 
 static bool afl_debug_enabled = false;       // General debug message
-static bool afl_debug_child_enabled = false; // Child specific debug message
+static bool afl_debug_unicorn_enabled = false; // Unicorn specific debug messages from child
 static std::chrono::time_point<std::chrono::steady_clock> t0;
 
 static void log_init() {
@@ -31,8 +31,8 @@ static void log_init() {
         afl_debug_enabled = true;
     }
 
-    if (getenv("AFL_DEBUG_CHILD")) {
-        afl_debug_child_enabled = true;
+    if (getenv("AFL_DEBUG_UNICORN")) {
+        afl_debug_unicorn_enabled = true;
     }
 
     t0 = std::chrono::steady_clock::now();
@@ -41,11 +41,11 @@ static void log_init() {
 static void log(bool in_child, const char* fmt, ...) {
     va_list args;
 
-    if (likely(!afl_debug_enabled && !afl_debug_child_enabled)) {
+    if (likely(!afl_debug_enabled && !afl_debug_unicorn_enabled)) {
         return;
     }
 
-    if (in_child && !afl_debug_child_enabled) {
+    if (in_child && !afl_debug_unicorn_enabled) {
         return;
     }
 
@@ -64,7 +64,7 @@ static void log(bool in_child, const char* fmt, ...) {
                 .count());
     }
 
-    if (in_child && afl_debug_child_enabled) {
+    if (in_child && afl_debug_unicorn_enabled) {
         pid_t p = getpid();
 
         fprintf(stderr, "[%04" PRId32 "] ", p);


### PR DESCRIPTION
As of now, `AFL_DEBUG_CHILD` enables unicorn debugging messages in the child process.
If one uses debug prints in the unicorn harness, this may easily lead to confusion, as a lot of messages about translations would be printed as well.

This PR adds an additional `AFL_DEBUG_UNICORN` env variable to toggle whether this translation output shall be printed as well, or not.
Probably, minor changes to AFL++ are needed as well, to surpress:
```
[!] WARNING: Mistyped AFL environment variable: AFL_DEBUG_UNICORN=1
Did you mean AFL_DEBUG?
```

Besides this, I also added some documentation about this logging differences in the README.md