### PR TITLE
Fix: Unicorn build paths in top-level Makefile and Rust bindings' build.rs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ build:
 
 unicorn/build/libunicorn-common.a:
 	git submodule update --init --recursive
-	cmake -S unicorn/ -B unicorn/build -D BUILD_SHARED_LIBS=no
-	$(MAKE) -C ./unicorn/build -j8
+	cmake -S unicorn/ -B build/unicorn -D BUILD_SHARED_LIBS=no
+	$(MAKE) -C ./build/unicorn -j8
 
 build/libunicornafl: build unicorn/build/libunicorn-common.a
 	cd ./build && cmake .. -D BUILD_SHARED_LIBS=no

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -54,7 +54,6 @@ use alloc::{boxed::Box, rc::Rc, vec::Vec};
 use core::{cell::UnsafeCell, ptr};
 use ffi::uc_handle;
 use libc::c_void;
-use unicorn_const::{uc_error, Arch, HookType, MemRegion, MemType, Mode, Permission, Query};
 
 #[derive(Debug)]
 pub struct Context {


### PR DESCRIPTION
I ran into some issues while trying to use the Rust bindings and eventually realized that the Unicorn build directory used in the top-level Makefile didn't match the paths used in `bindings/rust/build.rs`.

This PR updates the Unicorn build path in `Makefile` to use `build/unicorn` so that it's created in the location where `build.rs` expects it to be. Another minor change was also made to `bindings/rust/src/lib.rs` to remove warnings about globbed re-exported symbols.