### PR TITLE
Add cmplog

### DIFF
--- a/include/cmplog.h
+++ b/include/cmplog.h
@@ -1,0 +1,92 @@
+/*
+   american fuzzy lop++ - cmplog header
+   ------------------------------------
+
+   Originally written by Michal Zalewski
+
+   Forkserver design by Jann Horn <jannhorn@googlemail.com>
+
+   Now maintained by Marc Heuse <mh@mh-sec.de>,
+                     Heiko Eissfeldt <heiko.eissfeldt@hexco.de>,
+                     Andrea Fioraldi <andreafioraldi@gmail.com>,
+                     Dominik Maier <mail@dmnk.co>
+
+   Copyright 2016, 2017 Google Inc. All rights reserved.
+   Copyright 2019-2024 AFLplusplus Project. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at:
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+   Shared code to handle the shared memory. This is used by the fuzzer
+   as well the other components like afl-tmin, afl-showmap, etc...
+
+ */
+
+#ifndef _AFL_CMPLOG_H
+#define _AFL_CMPLOG_H
+
+#include <stdint.h>
+#include "config.h"
+
+#define CMPLOG_LVL_MAX 3
+
+#define CMP_MAP_W 65536
+#define CMP_MAP_H 32
+#define CMP_MAP_RTN_H (CMP_MAP_H / 2)
+
+#define SHAPE_BYTES(x) (x + 1)
+
+#define CMP_TYPE_INS 0
+#define CMP_TYPE_RTN 1
+
+struct cmp_header {  // 16 bit = 2 bytes
+
+  unsigned hits : 6;       // up to 63 entries, we have CMP_MAP_H = 32
+  unsigned shape : 5;      // 31+1 bytes max
+  unsigned type : 1;       // 2: cmp, rtn
+  unsigned attribute : 4;  // 16 for arithmetic comparison types
+
+} __attribute__((packed));
+
+struct cmp_operands {
+
+  uint64_t v0;
+  uint64_t v0_128;
+  uint64_t v0_256_0;  // u256 is unsupported by any compiler for now, so future use
+  uint64_t v0_256_1;
+  uint64_t v1;
+  uint64_t v1_128;
+  uint64_t v1_256_0;
+  uint64_t v1_256_1;
+  uint8_t  unused[8];  // 2 bits could be used for "is constant operand"
+
+} __attribute__((packed));
+
+struct cmpfn_operands {
+
+  uint8_t v0[32];
+  uint8_t v0_len;
+  uint8_t v1[32];
+  uint8_t v1_len;
+
+} __attribute__((packed));
+
+typedef struct cmp_operands cmp_map_list[CMP_MAP_H];
+
+struct cmp_map {
+
+  struct cmp_header   headers[CMP_MAP_W];
+  struct cmp_operands log[CMP_MAP_W][CMP_MAP_H];
+
+};
+
+/* Execs the child */
+
+struct afl_forkserver;
+void cmplog_exec_child(struct afl_forkserver *fsrv, char **argv);
+
+#endif
+

--- a/include/priv.h
+++ b/include/priv.h
@@ -20,6 +20,7 @@
 /* Copied from aflpp/types.h to talk to forkserver */
 #define FS_OPT_ENABLED 0x80000001
 #define FS_OPT_SHDMEM_FUZZ 0x01000000
+#define FS_OPT_NEWCMPLOG 0x02000000
 
 /**
  * The correct fds for reading and writing pipes

--- a/unicornafl.cpp
+++ b/unicornafl.cpp
@@ -1,6 +1,7 @@
 #include "unicornafl.h"
 #include "config.h"
 #include "priv.h"
+#include "cmplog.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -398,9 +399,7 @@ class UCAFL {
         }
     }
 
-    void _uc_hook_sub_impl(uint64_t cur_loc, uint64_t arg1, uint64_t arg2,
-                           uint32_t size) {
-
+    void _uc_hook_cmpcov(uint64_t cur_loc, uint64_t arg1, uint64_t arg2, uint32_t size) {
         if (size >= 64) {
             if (unlikely(MAP_SIZE - cur_loc < 8))
                 cur_loc -= 8;
@@ -414,6 +413,53 @@ class UCAFL {
                 cur_loc -= 2;
             this->_uc_hook_sub_impl_16(cur_loc, arg1, arg2);
         }
+    }
+
+    void _uc_hook_cmplog(uint64_t cur_loc, uint64_t arg1, uint64_t arg2, uint32_t size) {
+        struct cmp_map* map = this->cmpmap_;
+
+        uintptr_t k = (uintptr_t)cur_loc & (CMP_MAP_W - 1);
+        uint32_t shape = 0;
+        switch (size) {
+            case 16:
+                shape = 1;
+                break;
+            case 32:
+                shape = 3;
+                break;
+            case 64:
+                shape = 7;
+                break;
+            default:
+                break;
+        }
+
+        // get hits count
+        uint16_t hits;
+        if (map->headers[k].type != CMP_TYPE_INS) {
+            map->headers[k].type = CMP_TYPE_INS;
+            map->headers[k].hits = 1;
+            map->headers[k].shape = shape;
+            hits = 0;
+        } else {
+            hits = map->headers[k].hits++;
+            if (map->headers[k].shape < shape) {
+                map->headers[k].shape = shape;
+            }
+        }
+
+        hits &= CMP_MAP_H - 1;
+        map->log[k][hits].v0 = arg1;
+        map->log[k][hits].v1 = arg2;
+    }
+
+    void _uc_hook_sub_impl(uint64_t cur_loc, uint64_t arg1, uint64_t arg2,
+                           uint32_t size) {
+        if (this->has_cmplog_) {
+            return _uc_hook_cmplog(cur_loc, arg1, arg2, size);
+        }
+
+        _uc_hook_cmpcov(cur_loc, arg1, arg2, size);
     }
 
     static void _uc_hook_sub_cmp(uc_engine* uc, uint64_t address, uint64_t arg1,
@@ -462,23 +508,27 @@ class UCAFL {
             exit(1);
         }
 
-        // These two hooks are for compcov and may not be supported by the arch.
-        err = uc_hook_add(this->uc_, &this->h3_, UC_HOOK_TCG_OPCODE,
-                          (void*)_uc_hook_sub, (void*)this, 1, 0, UC_TCG_OP_SUB,
-                          UC_TCG_OP_FLAG_DIRECT);
+        // If we should use Laf-Intel or Red-Queen do add CMP hooks
+        if (this->has_cmpcov_ || this->has_cmplog_) {
 
-        if (err) {
-            ERR("Failed to setup UC_TCG_OP_SUB direct hook.\n");
-            exit(1);
-        }
+            // These two hooks may not be supported by the arch.
+            err = uc_hook_add(this->uc_, &this->h3_, UC_HOOK_TCG_OPCODE,
+                            (void*)_uc_hook_sub, (void*)this, 1, 0, UC_TCG_OP_SUB,
+                            UC_TCG_OP_FLAG_DIRECT);
 
-        err = uc_hook_add(this->uc_, &this->h4_, UC_HOOK_TCG_OPCODE,
-                          (void*)_uc_hook_sub_cmp, (void*)this, 1, 0,
-                          UC_TCG_OP_SUB, UC_TCG_OP_FLAG_CMP);
+            if (err) {
+                ERR("Failed to setup UC_TCG_OP_SUB direct hook.\n");
+                exit(1);
+            }
 
-        if (err) {
-            ERR("Failed to setup UC_TCG_OP_SUB cmp hook.\n");
-            exit(1);
+            err = uc_hook_add(this->uc_, &this->h4_, UC_HOOK_TCG_OPCODE,
+                            (void*)_uc_hook_sub_cmp, (void*)this, 1, 0,
+                            UC_TCG_OP_SUB, UC_TCG_OP_FLAG_CMP);
+
+            if (err) {
+                ERR("Failed to setup UC_TCG_OP_SUB cmp hook.\n");
+                exit(1);
+            }
         }
     }
 
@@ -527,6 +577,29 @@ class UCAFL {
             }
 
             this->has_afl_ = false;
+        }
+
+        char* cmplog_map_id_str = getenv(CMPLOG_SHM_ENV_VAR);
+        this->has_cmpcov_ = !!getenv("UNICORN_AFL_CMPCOV");
+
+        if (cmplog_map_id_str) {
+            if (this->has_cmpcov_) {
+                ERR("CMPLOG and CMPCOV turned on at the same time!\n");
+                ERR("I'll turn off CMPCOV.\n");
+                this->has_cmpcov_ = false;
+            }
+
+            int cmplog_map_id = atoi(cmplog_map_id_str);
+            this->cmpmap_ = (struct cmp_map*)shmat(cmplog_map_id, NULL, 0);
+
+            if (this->cmpmap_ == (void*)-1) {
+                ERR("Can't get the afl cmp-mapping area.\n");
+                exit(0);
+            }
+
+            this->has_cmplog_ = true;
+        } else {
+            this->has_cmplog_ = false;
         }
     }
 
@@ -866,6 +939,10 @@ class UCAFL {
     bool has_afl_;
     uint32_t afl_inst_rms_;
     uint64_t afl_prev_loc_;
+
+    bool has_cmpcov_;
+    bool has_cmplog_;
+    struct cmp_map* cmpmap_;
 
     // Fake signal value
     int wifsignaled_;

--- a/unicornafl.cpp
+++ b/unicornafl.cpp
@@ -616,7 +616,7 @@ class UCAFL {
         if (this->afl_testcase_ptr_) {
             /* Parent supports testcases via shared map - and the user wants to
              * use it. Tell AFL. */
-            status = (FS_OPT_ENABLED | FS_OPT_SHDMEM_FUZZ);
+            status = (FS_OPT_ENABLED | FS_OPT_SHDMEM_FUZZ | FS_OPT_NEWCMPLOG);
             /* Phone home and tell the parent that we're OK. If parent isn't
                there, assume we're not running in forkserver mode and just
                execute program. */


### PR DESCRIPTION
This is cmplog realization for unicorn-afl.

`CMPCOV` will be turned on when `UNICORN_AFL_CMPCOV` env exists (now it is turned off by default).
`CMPLOG` will be turned on when `__AFL_CMPLOG_SHM_ID` env exists.

I've tested this code for ARM32 firmware (unicorn version should be >= 2.1.2) with LibAFL.
AFL++ should be patched a little bit to allow cmplog with `-U` option.
