### PR TITLE
Make unicornafl more Rust-friendly and sync with newest unicorn-engine Rust crate

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,3 +4,9 @@ The project builds a bridge between AFL++ and unicorn engine.
 You can fuzz unicorn targets using python, rust, and C.
 
 Check out [the examples](https://github.com/AFLplusplus/AFLplusplus/tree/stable/unicorn_mode/samples) in AFLplusplus/unicorn_mode
+
+TODO:
+
+- [] Python/C bindings
+- [] cmplog support
+- [] libafl upstream

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
 use std::{
-    ffi::c_uchar,
+    ffi::{c_uchar, CStr},
     os::raw::{c_char, c_void},
+    path::PathBuf,
 };
 
-use target::child_fuzz;
-use unicorn_engine::{ffi::uc_handle, uc_error};
+use executor::UnicornFuzzData;
+use unicorn_engine::{uc_error, unicorn_const::uc_engine, Unicorn};
 
 pub mod executor;
 pub mod harness;
@@ -41,7 +42,7 @@ impl From<uc_error> for uc_afl_ret {
 
 #[allow(non_camel_case_types)]
 pub type uc_afl_cb_place_input_t = extern "C" fn(
-    uc: uc_handle,
+    uc: *mut uc_engine,
     input: *const c_uchar,
     input_len: usize,
     persistent_round: u64,
@@ -50,7 +51,7 @@ pub type uc_afl_cb_place_input_t = extern "C" fn(
 
 #[allow(non_camel_case_types)]
 pub type uc_afl_cb_validate_crash_t = extern "C" fn(
-    uc: uc_handle,
+    uc: *mut uc_engine,
     unicorn_result: uc_error,
     input: *const c_uchar,
     input_len: usize,
@@ -59,12 +60,76 @@ pub type uc_afl_cb_validate_crash_t = extern "C" fn(
 ) -> bool;
 
 #[allow(non_camel_case_types)]
-pub type uc_afl_fuzz_cb_t = extern "C" fn(uc: uc_handle, data: *mut c_void) -> uc_error;
+pub type uc_afl_fuzz_cb_t = extern "C" fn(uc: *mut uc_engine, data: *mut c_void) -> uc_error;
 
+/// Customized afl fuzz routine entrypoint for Rust user.
+///
+/// If you want to use default crash validation callback, pass
+/// [`dummy_uc_validate_crash_callback`][target::dummy_uc_validate_crash_callback].
+///
+/// If you want to use default fuzz callback, pass
+/// [`dummy_uc_fuzz_callback`][target::dummy_uc_fuzz_callback].
+///
+/// `exits` means instruction addresses that stop the execution. You can pass
+/// an empty vec here if there is not explicit exit.
+///
+/// If `always_validate` is true, then `validate_crash_cb` is invoked everytime
+/// regardless of the result of execution; Otherwise, only failed execution will
+/// invoke such callback.
+///
+/// `persistent_iters` is the number of persistent execution rounds.
+pub fn afl_fuzz_custom<'a, D: 'a>(
+    uc: Unicorn<'a, UnicornFuzzData<D>>,
+    input_file: Option<PathBuf>,
+    place_input_cb: impl FnMut(&mut Unicorn<'a, UnicornFuzzData<D>>, &[u8], u64) -> bool + 'a,
+    validate_crash_cb: impl FnMut(&mut Unicorn<'a, UnicornFuzzData<D>>, Result<(), uc_error>, &[u8], u64) -> bool
+        + 'a,
+    fuzz_callback: impl FnMut(&mut Unicorn<'a, UnicornFuzzData<D>>) -> Result<(), uc_error> + 'a,
+    exits: Vec<u64>,
+    always_validate: bool,
+    persistent_iters: u32,
+) -> Result<(), uc_afl_ret> {
+    target::child_fuzz(
+        uc,
+        input_file,
+        persistent_iters,
+        place_input_cb,
+        validate_crash_cb,
+        fuzz_callback,
+        exits,
+        always_validate,
+        true,
+    )
+}
+
+/// Simplified afl fuzz routine entrypoint for Rust user.
+///
+/// If you want to manually validate crash or kick fuzzing, call [`afl_fuzz_custom`].
+pub fn afl_fuzz<'a, D: 'a>(
+    uc: Unicorn<'a, UnicornFuzzData<D>>,
+    input_file: Option<PathBuf>,
+    place_input_cb: impl FnMut(&mut Unicorn<'a, UnicornFuzzData<D>>, &[u8], u64) -> bool + 'a,
+    exits: Vec<u64>,
+    always_validate: bool,
+    persistent_iters: u32,
+) -> Result<(), uc_afl_ret> {
+    afl_fuzz_custom(
+        uc,
+        input_file,
+        place_input_cb,
+        target::dummy_uc_validate_crash_callback,
+        target::dummy_uc_fuzz_callback,
+        exits,
+        always_validate,
+        persistent_iters,
+    )
+}
+
+/// Fuzzing entrypoint for FFI
 #[no_mangle]
 #[allow(non_camel_case_types)]
 pub extern "C" fn uc_afl_fuzz(
-    uc: uc_handle,
+    uc_handle: *mut uc_engine,
     input_file: *const c_char,
     place_input_callback: uc_afl_cb_place_input_t,
     exits: *const u64,
@@ -74,31 +139,25 @@ pub extern "C" fn uc_afl_fuzz(
     persistent_iters: u32,
     data: *mut c_void,
 ) -> uc_afl_ret {
-    match child_fuzz(
-        uc,
+    uc_afl_fuzz_internal(
+        uc_handle,
         input_file,
-        persistent_iters,
         place_input_callback,
-        validate_crash_callback,
-        if exits.is_null() {
-            vec![]
-        } else {
-            unsafe { std::slice::from_raw_parts(exits, exit_count) }.to_vec()
-        },
+        exits,
+        exit_count,
         None,
+        validate_crash_callback,
         always_validate,
-        true,
+        persistent_iters,
         data,
-    ) {
-        Ok(_) => uc_afl_ret::UC_AFL_RET_OK,
-        Err(e) => e,
-    }
+    )
 }
 
+/// Custom fuzzing entrypoint for FFI
 #[no_mangle]
 #[allow(non_camel_case_types)]
 pub extern "C" fn uc_afl_fuzz_custom(
-    uc: uc_handle,
+    uc_handle: *mut uc_engine,
     input_file: *const c_char,
     place_input_callback: uc_afl_cb_place_input_t,
     fuzz_callback: uc_afl_fuzz_cb_t,
@@ -107,19 +166,147 @@ pub extern "C" fn uc_afl_fuzz_custom(
     persistent_iters: u32,
     data: *mut c_void,
 ) -> uc_afl_ret {
-    match child_fuzz(
-        uc,
+    uc_afl_fuzz_internal(
+        uc_handle,
         input_file,
-        persistent_iters,
         place_input_callback,
-        validate_crash_callback,
-        vec![],
+        std::ptr::null(),
+        0,
         Some(fuzz_callback),
+        validate_crash_callback,
         always_validate,
-        true,
+        persistent_iters,
         data,
-    ) {
+    )
+}
+
+// In the implementation, there is a lot of manually created closures.
+// This is due to the fact that two closure have different types even if
+// their signature is the same. As a result, we must split the invocation
+// to avoid checking the emptyness inside every round.
+fn uc_afl_fuzz_internal(
+    uc_handle: *mut uc_engine,
+    input_file: *const c_char,
+    place_input_callback: uc_afl_cb_place_input_t,
+    exits: *const u64,
+    exit_count: usize,
+    fuzz_callback: Option<uc_afl_fuzz_cb_t>,
+    validate_crash_callback: Option<uc_afl_cb_validate_crash_t>,
+    always_validate: bool,
+    persistent_iters: u32,
+    data: *mut c_void,
+) -> uc_afl_ret {
+    let fuzz_data = UnicornFuzzData::new(data);
+    let uc = match unsafe { Unicorn::from_handle_with_data(uc_handle, fuzz_data) } {
+        Ok(uc) => uc,
+        Err(err) => {
+            return err.into();
+        }
+    };
+
+    let place_input_cb = move |uc: &mut Unicorn<'_, UnicornFuzzData<*mut c_void>>,
+                               input: &[u8],
+                               persistent_round: u64| {
+        let handle = uc.get_handle();
+        let data = uc.get_data_mut().user_data;
+        (place_input_callback)(handle, input.as_ptr(), input.len(), persistent_round, data)
+    };
+    let validate_crash_cb = validate_crash_callback.map(|validate_crash_callback| {
+        move |uc: &mut Unicorn<'_, UnicornFuzzData<*mut c_void>>,
+              unicorn_result: Result<(), uc_error>,
+              input: &[u8],
+              persistent_round: u64| {
+            let handle = uc.get_handle();
+            let data = uc.get_data_mut().user_data;
+            let unicorn_result = if let Err(err) = unicorn_result {
+                err
+            } else {
+                uc_error::OK
+            };
+            (validate_crash_callback)(
+                handle,
+                unicorn_result,
+                input.as_ptr(),
+                input.len(),
+                persistent_round,
+                data,
+            )
+        }
+    });
+    let fuzz_cb = fuzz_callback.map(|fuzz_callback| {
+        move |uc: &mut Unicorn<'_, UnicornFuzzData<*mut c_void>>| {
+            let handle = uc.get_handle();
+            let data = uc.get_data_mut().user_data;
+            let unicorn_result = fuzz_callback(handle, data);
+            if unicorn_result == uc_error::OK {
+                Ok(())
+            } else {
+                Err(unicorn_result)
+            }
+        }
+    });
+
+    let input_file = if input_file.is_null() {
+        None
+    } else {
+        // legacy usage
+        let Ok(input_file_str) = unsafe { CStr::from_ptr(input_file) }.to_str() else {
+            return uc_afl_ret::UC_AFL_RET_FFI;
+        };
+        Some(PathBuf::from(input_file_str))
+    };
+
+    let exits = if exits.is_null() {
+        vec![]
+    } else {
+        unsafe { std::slice::from_raw_parts(exits, exit_count) }.to_vec()
+    };
+
+    let res = match (validate_crash_cb, fuzz_cb) {
+        (Some(validate_crash_cb), Some(fuzz_cb)) => afl_fuzz_custom(
+            uc,
+            input_file,
+            place_input_cb,
+            validate_crash_cb,
+            fuzz_cb,
+            exits,
+            always_validate,
+            persistent_iters,
+        ),
+        (Some(validate_crash_cb), None) => afl_fuzz_custom(
+            uc,
+            input_file,
+            place_input_cb,
+            validate_crash_cb,
+            target::dummy_uc_fuzz_callback,
+            exits,
+            always_validate,
+            persistent_iters,
+        ),
+        (None, Some(fuzz_cb)) => afl_fuzz_custom(
+            uc,
+            input_file,
+            place_input_cb,
+            target::dummy_uc_validate_crash_callback,
+            fuzz_cb,
+            exits,
+            always_validate,
+            persistent_iters,
+        ),
+        (None, None) => afl_fuzz_custom(
+            uc,
+            input_file,
+            place_input_cb,
+            target::dummy_uc_validate_crash_callback,
+            target::dummy_uc_fuzz_callback,
+            exits,
+            always_validate,
+            persistent_iters,
+        ),
+    };
+
+    match res {
         Ok(_) => uc_afl_ret::UC_AFL_RET_OK,
-        Err(e) => e,
+        Err(err) => err,
     }
 }


### PR DESCRIPTION
In this PR, there are two closely-related changes (it should be noted that **the functionality and logic are never changed and everything would just work fine, no breaking changes.**):

* Current code is synced with newest unicorn-engine Rust crate.

    Since the unicorn-engine binding and wrapper have been greatly refactored and improved.
* Some APIs and internal structures are refactored to be more Rust-friendly.

    The ultimate entrypoint is refactored into four functions in `lib.rs`: `afl_fuzz_custom`, `afl_fuzz`, `uc_afl_fuzz`, `uc_afl_fuzz_custom`. The first two are for Rust-users, and the last two are for FFI users (The real implementation is still the `child_fuzz` in `target.rs`, those four are just some wrappers).

    Since we can only expose fuzzing entrypoint to FFI users, the internal design, as a result, can be pure Rust, and no `extern "C"`, no `c_void`, no `*mut`. This could not only improve the maintenance of this library, but also potentially improve the performance for both Rust users and FFI users.