### PR TITLE
Fix iter count if we have afl++

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -114,7 +114,11 @@ pub fn child_fuzz<'a, D: 'a>(
             debug!("{}", s);
         }));
         let sched = QueueScheduler::new();
-        let iters = if run_once_if_no_afl_present { 1 } else { iters };
+        let iters = if !has_afl && run_once_if_no_afl_present {
+            1
+        } else {
+            iters
+        };
         let input_file = if has_afl { None } else { input_file };
         let stage = LegacyHarnessStage::new(iters as usize, map_size, input_file);
         let mut stages = tuple_list!(stage);


### PR DESCRIPTION
In my understanding, `run_once_if_no_afl_present` means if we detect there is no afl++, whether we should run once for target harness. As a result, we should check whether there is no afl++, otherwise even if we have afl++, the iter count is still 1.