### PR TITLE
Allow infinite iteration

### DIFF
--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -40,7 +40,7 @@ fn main() {
         place_input_cb,
         vec![0x100b, 0x1011],
         false,
-        1,
+        Some(1),
     )
     .expect("fail to fuzz?")
 }

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -10,45 +10,69 @@ use crate::executor::{UnicornAflExecutor, UnicornAflExecutorHook};
 pub fn forkserver_run_harness<'a, D, OT, H>(
     executor: &mut UnicornAflExecutor<'a, D, OT, H>,
     input_path: Option<PathBuf>,
-    iters: usize,
+    iters: Option<u64>,
 ) -> Result<(), libafl::Error>
 where
     D: 'a,
     H: UnicornAflExecutorHook<'a, D>,
 {
     let mut first_pass = true;
-    for execution_round in 0..iters {
-        if first_pass {
-            first_pass = false;
-        } else if let Some(parent_pipe_r) = &executor.uc.get_data().parent_pipe_r {
-            if crate::forkserver::read_u32_from_fd(parent_pipe_r).is_err() {
-                error!("[!] Error reading from parent pipe. Parent dead?");
-            }
+    if let Some(iters) = iters {
+        for persistent_round in 0..iters {
+            forkserver_run_harness_once(executor, &input_path, &mut first_pass, persistent_round)?;
         }
-        unsafe {
-            std::ptr::write_bytes(EDGES_MAP_PTR, 0, executor.uc.get_data().map_size() as usize);
-            std::ptr::write_volatile(EDGES_MAP_PTR, 1);
+        Ok(())
+    } else {
+        let mut persistent_round = 0u64;
+        loop {
+            forkserver_run_harness_once(executor, &input_path, &mut first_pass, persistent_round)?;
+            persistent_round = persistent_round.wrapping_add(1);
         }
+    }
+}
 
-        let input_str;
-        let input = if let Some(input) = input_path.as_ref() {
-            input_str = std::fs::read(input)?;
-            input_str.as_slice()
-        } else {
-            unsafe { std::slice::from_raw_parts(INPUT_PTR, (*INPUT_LENGTH_PTR) as usize) }
-        };
+/// If this returns `Err`, this means there are something fatal happened in
+/// execution, this means the loop cannot proceed.
+fn forkserver_run_harness_once<'a, D, OT, H>(
+    executor: &mut UnicornAflExecutor<'a, D, OT, H>,
+    input_path: &Option<PathBuf>,
+    first_pass: &mut bool,
+    persistent_round: u64,
+) -> Result<(), libafl::Error>
+where
+    D: 'a,
+    H: UnicornAflExecutorHook<'a, D>,
+{
+    if *first_pass {
+        *first_pass = false;
+    } else if let Some(parent_pipe_r) = &executor.uc.get_data().parent_pipe_r {
+        if crate::forkserver::read_u32_from_fd(parent_pipe_r).is_err() {
+            error!("[!] Error reading from parent pipe. Parent dead?");
+        }
+    }
+    unsafe {
+        std::ptr::write_bytes(EDGES_MAP_PTR, 0, executor.uc.get_data().map_size() as usize);
+        std::ptr::write_volatile(EDGES_MAP_PTR, 1);
+    }
 
-        let exit_kind = executor.execute_internal(input, execution_round as u64)?;
+    let input_str;
+    let input = if let Some(input) = input_path.as_ref() {
+        input_str = std::fs::read(input)?;
+        input_str.as_slice()
+    } else {
+        unsafe { std::slice::from_raw_parts(INPUT_PTR, (*INPUT_LENGTH_PTR) as usize) }
+    };
 
-        let msg = if matches!(exit_kind, ExitKind::Ok) {
-            crate::forkserver::afl_child_ret::NEXT
-        } else {
-            crate::forkserver::afl_child_ret::FOUND_CRASH
-        };
-        if let Some(child_pipe_w) = &executor.uc.get_data().child_pipe_w {
-            if crate::forkserver::write_u32_to_fd(child_pipe_w, msg).is_err() {
-                error!("[!] Error writing to parent pipe. Parent dead?");
-            }
+    let exit_kind = executor.execute_internal(input, persistent_round)?;
+
+    let msg = if matches!(exit_kind, ExitKind::Ok) {
+        crate::forkserver::afl_child_ret::NEXT
+    } else {
+        crate::forkserver::afl_child_ret::FOUND_CRASH
+    };
+    if let Some(child_pipe_w) = &executor.uc.get_data().child_pipe_w {
+        if crate::forkserver::write_u32_to_fd(child_pipe_w, msg).is_err() {
+            error!("[!] Error writing to parent pipe. Parent dead?");
         }
     }
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -42,7 +42,7 @@ pub fn dummy_uc_validate_crash_callback<'a, D: 'a>(
 pub fn child_fuzz<'a, D: 'a>(
     uc: Unicorn<'a, UnicornFuzzData<D>>,
     input_file: Option<PathBuf>,
-    iters: u32,
+    iters: Option<u64>,
     callbacks: impl UnicornAflExecutorHook<'a, D>,
     exits: Vec<u64>,
     always_validate: bool,
@@ -79,20 +79,19 @@ pub fn child_fuzz<'a, D: 'a>(
             SHM_FUZZING = 1;
         }
         debug!("Map size is: {map_size}");
-        let executor = UnicornAflExecutor::new(uc, (), callbacks, always_validate, exits)?;
-        let mut forkserver_parent = crate::forkserver::UnicornAflForkserverParent::new(executor);
-        libafl_targets::start_forkserver(&mut forkserver_parent)?;
-        let mut executor = forkserver_parent.executor;
 
         let iters = if !has_afl && run_once_if_no_afl_present {
-            1
+            Some(1)
         } else {
             iters
         };
+        let executor =
+            UnicornAflExecutor::new(uc, (), callbacks, always_validate, exits, iters.is_none())?;
+        let mut forkserver_parent = crate::forkserver::UnicornAflForkserverParent::new(executor);
+        libafl_targets::start_forkserver(&mut forkserver_parent)?;
+        let mut executor = forkserver_parent.executor;
         let input_file = if has_afl { None } else { input_file };
-        if let Err(e) =
-            crate::harness::forkserver_run_harness(&mut executor, input_file, iters as usize)
-        {
+        if let Err(e) = crate::harness::forkserver_run_harness(&mut executor, input_file, iters) {
             // The error cannot be propagated since we are in child process now.
             // So just log.
             error!("Fuzzing fails with error from libafl: {e}");


### PR DESCRIPTION
In the C++ version, users pass 0 as iters to indicate the loop should be infinite, let's also provide this option in Rust version.

In this case, the TB cache is useless since it only works if the child process indeed crashes, which is rare and the edge gen hook will also add a little overhead.