### PR TITLE
Use std::io::pipe and upgrade to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "unicornafl"
 version = "3.0.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 use std::{
-    ffi::{c_uchar, CStr},
+    ffi::{CStr, c_uchar},
     os::raw::{c_char, c_void},
     path::PathBuf,
 };
 
 use executor::{UnicornAflExecutorCustomHook, UnicornAflExecutorHook, UnicornFuzzData};
-use unicorn_engine::{uc_error, unicorn_const::uc_engine, Unicorn};
+use unicorn_engine::{Unicorn, uc_error, unicorn_const::uc_engine};
 
 pub mod executor;
 mod forkserver;
@@ -119,7 +119,7 @@ pub fn afl_fuzz<'a, D: 'a>(
 }
 
 /// Fuzzing entrypoint for FFI
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(non_camel_case_types)]
 pub extern "C" fn uc_afl_fuzz(
     uc_handle: *mut uc_engine,
@@ -147,7 +147,7 @@ pub extern "C" fn uc_afl_fuzz(
 }
 
 /// Custom fuzzing entrypoint for FFI
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(non_camel_case_types)]
 pub extern "C" fn uc_afl_fuzz_custom(
     uc_handle: *mut uc_engine,

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
-use libafl_targets::{__afl_map_size, cmps::CMPLOG_ENABLED, EDGES_MAP_PTR, SHM_FUZZING};
+use libafl_targets::{__afl_map_size, EDGES_MAP_PTR, SHM_FUZZING, cmps::CMPLOG_ENABLED};
 use log::{debug, error, trace, warn};
-use unicorn_engine::{uc_error, Arch, RegisterARM, Unicorn};
+use unicorn_engine::{Arch, RegisterARM, Unicorn, uc_error};
 
 use crate::{
     executor::{CmpPolicy, UnicornAflExecutor, UnicornAflExecutorHook, UnicornFuzzData},


### PR DESCRIPTION
Rust 1.87.0 released today [brings `std::io::pipe`](https://blog.rust-lang.org/2025/05/15/Rust-1.87.0/), let's use it. Moreover, let's upgrade to Rust 2024 edition :)