### PR TITLE
Add C header and several improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,3 +99,19 @@ jobs:
         TOKEN: ${{ secrets.CRATES_IO_KEY }}
       run: |
         cargo login $TOKEN && cargo test && cargo publish
+
+  fmt-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cargo fmt
+        run: cargo fmt --check
+
+  fmt-toml-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install taplo
+        run: cargo install taplo
+      - uses: actions/checkout@v4
+      - name: Run taplo
+        run: taplo format --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install taplo
-        run: cargo install taplo
+        run: cargo install taplo-cli --locked
       - uses: actions/checkout@v4
       - name: Run taplo
         run: taplo format --check

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -98,8 +98,8 @@ jobs:
         CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
         # These are needed for Unicorn and cbindgen
         CIBW_BEFORE_ALL: >
-          apt-get update && apt-get install -y build-essential llvm-16-dev clang-16 \
-          libtool libtool-bin libglib2.0-dev make cmake automake meson ninja-build bison flex
+          yum install llvm llvm-devel clang clang-devel libtool glib2-devel \
+          make cmake automake meson ninja-build bison flex
         CIBW_BEFORE_BUILD: rustup show
         CIBW_BEFORE_BUILD_LINUX: >
           curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable --profile=minimal -y &&

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -16,19 +16,19 @@ jobs:
           - { 
               os: ubuntu-latest, 
               arch: x64, 
-              python-version: '3.8', 
+              python-version: 'cp38', 
               name: 'manylinux2014_x86_64'
             }
           - { 
               os: ubuntu-latest,
               arch: x32,
-              python-version: '3.8',
+              python-version: 'cp38',
               name: 'manylinux2014_i686'
             }
           - { 
               os: ubuntu-latest,
               arch: x64,
-              python-version: '3.8',
+              python-version: 'cp38',
               name: 'sdist'
             }
           # - { 

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -17,13 +17,13 @@ jobs:
               os: ubuntu-latest, 
               arch: x64, 
               python-version: 'cp38', 
-              name: 'manylinux2014_x86_64'
+              name: 'manylinux_x86_64'
             }
           - { 
               os: ubuntu-latest,
               arch: x32,
               python-version: 'cp38',
-              name: 'manylinux2014_i686'
+              name: 'manylinux_i686'
             }
           # - { 
           #     os: macos-latest,

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -38,6 +38,8 @@ jobs:
           #     name: 'macos_x86_64'
           #   }
     steps:
+    - uses: actions/checkout@v4
+
     - name: set up python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -94,7 +94,7 @@ jobs:
     - name: build ${{ matrix.config.platform || matrix.config.os }} binaries
       run: cibuildwheel --output-dir wheelhouse
       env:
-        CIBW_BUILD: '${{ matrix.config.python-version }}-{{ matrix.config.name }}'
+        CIBW_BUILD: '${{ matrix.config.python-version }}-${{ matrix.config.name }}'
         # rust doesn't seem to be available for musl linux on i686
         CIBW_SKIP: '*-musllinux_i686'
         # we build for "alt_arch_name" if it exists, else 'auto'

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -53,11 +53,11 @@ jobs:
     - name: Setup Rust cache
       uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ matrix.alt_arch_name }}
+        key: ${{ matrix.config.alt_arch_name }}
 
     - name: Get pip cache dir
       id: pip-cache
-      if: matrix.os != 'windows-latest'
+      if: matrix.config.os != 'windows-latest'
       run: |
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     
@@ -65,7 +65,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ steps.pip-cache.outputs.dir || steps.pip-cache-win.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}
+        key: ${{ runner.os }}-pip-${{ matrix.config.python-version }}
   
     - name: install python dependencies
       run: pip install -U setuptools wheel twine cibuildwheel platformdirs
@@ -84,22 +84,22 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ steps.cibuildwheel-cache.outputs.dir }}
-        key: ${{ runner.os }}-cibuildwheel-${{ matrix.python-version }}
+        key: ${{ runner.os }}-cibuildwheel-${{ matrix.config.python-version }}
 
     - name: build sdist
-      if: matrix.os == 'ubuntu' && matrix.python-version == 'cp310'
+      if: matrix.config.os == 'ubuntu' && matrix.config.python-version == 'cp310'
       run: |
         pip install maturin build
         python -m build --sdist -o wheelhouse
 
-    - name: build ${{ matrix.platform || matrix.os }} binaries
+    - name: build ${{ matrix.config.platform || matrix.config.os }} binaries
       run: cibuildwheel --output-dir wheelhouse
       env:
-        CIBW_BUILD: '${{ matrix.python-version }}-*'
+        CIBW_BUILD: '${{ matrix.config.python-version }}-*'
         # rust doesn't seem to be available for musl linux on i686
         CIBW_SKIP: '*-musllinux_i686'
         # we build for "alt_arch_name" if it exists, else 'auto'
-        CIBW_ARCHS: ${{ matrix.alt_arch_name || 'auto' }}
+        CIBW_ARCHS: ${{ matrix.config.alt_arch_name || 'auto' }}
         CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH" CARGO_TERM_COLOR="always"'
         CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
         CIBW_BEFORE_BUILD: rustup show
@@ -111,7 +111,7 @@ jobs:
         # CIBW_TEST_SKIP: '*-macosx_arm64 *-macosx_universal2:arm64'
         CIBW_BUILD_VERBOSITY: 1
 
-    - run: ${{ matrix.ls || 'ls -lh' }} wheelhouse/
+    - run: ${{ matrix.config.ls || 'ls -lh' }} wheelhouse/
 
     - name: '📤 Upload artifact'
       uses: actions/upload-artifact@v4

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -16,19 +16,19 @@ jobs:
           - { 
               os: ubuntu-latest, 
               arch: x64, 
-              python-ver: '3.8', 
+              python-version: '3.8', 
               name: 'manylinux2014_x86_64'
             }
           - { 
               os: ubuntu-latest,
               arch: x32,
-              python-ver: '3.8',
+              python-version: '3.8',
               name: 'manylinux2014_i686'
             }
           - { 
               os: ubuntu-latest,
               arch: x64,
-              python-ver: '3.8',
+              python-version: '3.8',
               name: 'sdist'
             }
           # - { 
@@ -106,9 +106,9 @@ jobs:
         CIBW_BEFORE_BUILD_LINUX: >
           curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable --profile=minimal -y &&
           rustup show
-        CIBW_TEST_COMMAND: 'pytest {project}/test'
-        CIBW_TEST_REQUIRES: pytest requests
-        CIBW_TEST_SKIP: '*-macosx_arm64 *-macosx_universal2:arm64'
+        # CIBW_TEST_COMMAND: 'pytest {project}/test'
+        # CIBW_TEST_REQUIRES: pytest requests
+        # CIBW_TEST_SKIP: '*-macosx_arm64 *-macosx_universal2:arm64'
         CIBW_BUILD_VERBOSITY: 1
 
     - run: ${{ matrix.ls || 'ls -lh' }} wheelhouse/

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -98,7 +98,7 @@ jobs:
         CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
         # These are needed for Unicorn and cbindgen
         CIBW_BEFORE_ALL: >
-          yum update && yum install llvm llvm-devel clang clang-devel libtool glib2-devel meson ninja-build bison flex
+          yum update -y && yum install -y llvm llvm-devel clang clang-devel libtool glib2-devel meson ninja-build bison flex
         CIBW_BEFORE_BUILD: rustup show
         CIBW_BEFORE_BUILD_LINUX: >
           curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable --profile=minimal -y &&

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -98,8 +98,7 @@ jobs:
         CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
         # These are needed for Unicorn and cbindgen
         CIBW_BEFORE_ALL: >
-          yum update && yum install llvm llvm-devel clang clang-devel libtool glib2-devel \
-          meson ninja-build bison flex
+          yum update && yum install llvm llvm-devel clang clang-devel libtool glib2-devel meson ninja-build bison flex
         CIBW_BEFORE_BUILD: rustup show
         CIBW_BEFORE_BUILD_LINUX: >
           curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable --profile=minimal -y &&

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -25,12 +25,6 @@ jobs:
               python-version: 'cp38',
               name: 'manylinux2014_i686'
             }
-          - { 
-              os: ubuntu-latest,
-              arch: x64,
-              python-version: 'cp38',
-              name: 'sdist'
-            }
           # - { 
           #     os: macos-latest,
           #     arch: x64,
@@ -39,6 +33,11 @@ jobs:
           #   }
     steps:
     - uses: actions/checkout@v4
+
+    - name: '🛠️ Set up dependency of Unicorn'
+      run: |
+        sudo apt update && sudo apt install -y build-essential \
+        libtool libtool-bin libglib2.0-dev make cmake automake meson ninja-build bison flex
 
     - name: set up python
       uses: actions/setup-python@v4
@@ -87,7 +86,7 @@ jobs:
         key: ${{ runner.os }}-cibuildwheel-${{ matrix.config.python-version }}
 
     - name: build sdist
-      if: matrix.config.os == 'ubuntu' && matrix.config.python-version == 'cp310'
+      if: matrix.config.os == 'ubuntu-latest' && matrix.config.python-version == 'cp38'
       run: |
         pip install maturin build
         python -m build --sdist -o wheelhouse
@@ -95,7 +94,7 @@ jobs:
     - name: build ${{ matrix.config.platform || matrix.config.os }} binaries
       run: cibuildwheel --output-dir wheelhouse
       env:
-        CIBW_BUILD: '${{ matrix.config.python-version }}-*'
+        CIBW_BUILD: '${{ matrix.config.python-version }}-{{ matrix.config.name }}'
         # rust doesn't seem to be available for musl linux on i686
         CIBW_SKIP: '*-musllinux_i686'
         # we build for "alt_arch_name" if it exists, else 'auto'

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -98,8 +98,8 @@ jobs:
         CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
         # These are needed for Unicorn and cbindgen
         CIBW_BEFORE_ALL: >
-          yum install llvm llvm-devel clang clang-devel libtool glib2-devel \
-          make cmake automake meson ninja-build bison flex
+          yum update && yum install llvm llvm-devel clang clang-devel libtool glib2-devel \
+          meson ninja-build bison flex
         CIBW_BEFORE_BUILD: rustup show
         CIBW_BEFORE_BUILD_LINUX: >
           curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable --profile=minimal -y &&

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -34,11 +34,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: '🛠️ Set up dependency of Unicorn'
-      run: |
-        sudo apt update && sudo apt install -y build-essential \
-        libtool libtool-bin libglib2.0-dev make cmake automake meson ninja-build bison flex
-
     - name: set up python
       uses: actions/setup-python@v4
       with:
@@ -101,6 +96,10 @@ jobs:
         CIBW_ARCHS: ${{ matrix.config.alt_arch_name || 'auto' }}
         CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH" CARGO_TERM_COLOR="always"'
         CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
+        # These are needed for Unicorn and cbindgen
+        CIBW_BEFORE_ALL: >
+          apt-get update && apt-get install -y build-essential llvm-16-dev clang-16 \
+          libtool libtool-bin libglib2.0-dev make cmake automake meson ninja-build bison flex
         CIBW_BEFORE_BUILD: rustup show
         CIBW_BEFORE_BUILD_LINUX: >
           curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable --profile=minimal -y &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,18 +7,22 @@ rust-version = "1.87"
 
 [dependencies]
 # Unreleased 0.15.3
-libafl_targets = { git = "https://github.com/AFLplusplus/LibAFL", features = [
-    "pointer_maps", "forkserver", "cmplog", "cmplog_extended_instrumentation"], rev = "d5ecf7304dbd377df94d08aed658199eed2956af"}
-libafl = { git = "https://github.com/AFLplusplus/LibAFL", rev = "d5ecf7304dbd377df94d08aed658199eed2956af"}
-libafl_bolts = { git = "https://github.com/AFLplusplus/LibAFL", rev = "d5ecf7304dbd377df94d08aed658199eed2956af"}
+libafl_targets = { version = "0.15.3", features = [
+  "pointer_maps",
+  "forkserver",
+  "cmplog",
+  "cmplog_extended_instrumentation",
+] }
+libafl = "0.15.3"
+libafl_bolts = "0.15.3"
 
-serde ={ version = "1.0", features = ["derive"] }
-unicorn-engine = { git = "https://github.com/unicorn-engine/unicorn", branch = "dev"}
+serde = { version = "1.0", features = ["derive"] }
+unicorn-engine = { git = "https://github.com/unicorn-engine/unicorn", branch = "dev" }
 log = "0.4"
 nix = { version = "0.29", features = ["signal"] }
 env_logger = { version = "0.11", optional = true }
-pyo3 = { version = "0.24.0", features = ["extension-module"], optional = true}
-pyo3-log = { version = "0.12.2", optional = true}
+pyo3 = { version = "0.24.0", features = ["extension-module"], optional = true }
+pyo3-log = { version = "0.12.2", optional = true }
 
 [features]
 default = []
@@ -30,3 +34,8 @@ crate-type = ["cdylib", "rlib"] # For python
 
 [[example]]
 name = "sample"
+
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ rust-version = "1.87"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# Unreleased 0.15.3
 libafl_targets = { version = "0.15.3", features = [
   "pointer_maps",
   "forkserver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bindings = ["unicorn-engine/dynamic_linkage", "pyo3", "pyo3-log", "env_logger"]
 
 [lib]
 name = "unicornafl"
-crate-type = ["cdylib", "rlib"] # For python
+crate-type = ["cdylib", "staticlib", "rlib"] # For python
 
 [[example]]
 name = "sample"

--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -75,5 +75,5 @@ fn main() {
     };
 
     let input_file = input_file.map(PathBuf::from);
-    afl_fuzz(uc, input_file, place_input_cb, exits, false, Some(1)).expect("fail to fuzz?")
+    afl_fuzz(uc, input_file, place_input_cb, exits, Some(1)).expect("fail to fuzz?")
 }

--- a/include/unicornafl.h
+++ b/include/unicornafl.h
@@ -1,0 +1,86 @@
+#ifndef UNICORNAFL_H
+#define UNICORNAFL_H
+
+#include "unicorn/unicorn.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __GNUC__
+#define UNICORNAFL_EXPORT __attribute__((visibility("default")))
+#else
+#define UNICORNAFL_EXPORT
+#endif
+
+#define MIN_UC_VERSION 0x02000100
+
+typedef enum uc_afl_ret {
+    UC_AFL_RET_OK = 0,
+    UC_AFL_RET_ERROR,
+    UC_AFL_RET_CHILD,
+    UC_AFL_RET_NO_AFL,
+    UC_AFL_RET_CALLED_TWICE,
+    UC_AFL_RET_FINISHED,
+    UC_AFL_RET_INVALID_UC,
+    UC_AFL_RET_UC_ERR,
+    UC_AFL_RET_LIBAFL,
+    UC_AFL_RET_FFI,
+} uc_afl_ret;
+
+typedef bool (*uc_afl_cb_place_input_t)(uc_engine* uc, char* input,
+                                        size_t input_len,
+                                        uint32_t persistent_round, void* data);
+
+typedef bool (*uc_afl_cb_validate_crash_t)(uc_engine* uc, uc_err unicorn_result,
+                                           char* input, int input_len,
+                                           int persistent_round, void* data);
+
+typedef uc_err (*uc_afl_fuzz_cb_t)(uc_engine *uc, void *data);
+
+//
+//  Start our fuzzer.
+//
+//  If no afl-fuzz instance is found, this function is almost identical to uc_emu_start()
+//  
+//  @uc: The uc_engine return-ed from uc_open().
+//  @input_file: This usually is the input file name provided by the command argument.
+//  @place_input_callback: This callback is triggered every time a new child is generated. It returns 
+//                         true if the input is accepted, or the input would be skipped.
+//  @exits: All possible exits.
+//  @exit_count: The count of the @exits array.
+//  @validate_crash_callback: This callback is triggered every time to check if we are crashed.                     
+//  @always_validate: If this is set to False, validate_crash_callback will be only triggered if
+//                    uc_emu_start (which is called internally by uc_afl_fuzz) returns an error. Or
+//                    the validate_crash_callback will be triggered every time.
+//  @persistent_iters: Fuzz how many times before forking a new child.
+//  @data: The extra data user provides.
+//
+//  @uc_afl_ret: The error the fuzzer returns.
+UNICORNAFL_EXPORT
+uc_afl_ret uc_afl_fuzz(uc_engine* uc, char* input_file,
+                       uc_afl_cb_place_input_t place_input_callback,
+                       uint64_t* exits, size_t exit_count,
+                       uc_afl_cb_validate_crash_t validate_crash_callback,
+                       bool always_validate, uint32_t persistent_iters,
+                       void* data);
+
+//
+// By default, uc_afl_fuzz internall calls uc_emu_start only once and if uc_emu_stop
+// is called, the child will stop fuzzing current test case.
+//
+// To implement more complex fuzzing logic, pass an extra fuzzing_callback with this API.
+//
+UNICORN_EXPORT
+uc_afl_ret uc_afl_fuzz_custom(uc_engine* uc, char* input_file,
+                              uc_afl_cb_place_input_t place_input_callback,
+                              uc_afl_fuzz_cb_t fuzz_callbck,
+                              uc_afl_cb_validate_crash_t validate_crash_callback,
+                              bool always_validate, uint32_t persistent_iters,
+                              void* data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,12 @@ build-backend = "maturin"
 name = "unicornafl"
 requires-python = ">=3.8"
 classifiers = [
-    "Programming Language :: Rust",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
+  "Programming Language :: Rust",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
-dependencies = [
-    "unicorn>=2.1.3"
-]
+dependencies = ["unicorn>=2.1.3"]
 
 [tool.maturin]
 bindings = "pyo3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,6 @@ pub fn afl_fuzz<'a, D: 'a>(
     input_file: Option<PathBuf>,
     place_input_cb: impl FnMut(&mut Unicorn<'a, UnicornFuzzData<D>>, &[u8], u64) -> bool + 'a,
     exits: Vec<u64>,
-    always_validate: bool,
     persistent_iters: Option<u64>,
 ) -> Result<(), uc_afl_ret> {
     afl_fuzz_custom(
@@ -114,7 +113,7 @@ pub fn afl_fuzz<'a, D: 'a>(
             target::dummy_uc_fuzz_callback,
         ),
         exits,
-        always_validate,
+        false,
         persistent_iters,
     )
 }


### PR DESCRIPTION
This PR includes the following changes:

* Add C header

    Since the Rust binding API is managed to be consistent with previous C++ version, just copy-and-paste the previous C header, with a little modification to `uc_afl_ret` to include more variants.

    And I also specify "staticlib" as another crate-type to allow C users to statically link this library.
* Update LibAFL dependencies

    0.15.3 version has been released.
* Add toml formatting

    Same as what LibAFL does, using `taplo` as a TOML format tool. This will not only format `Cargo.toml`, but also format `py-project.toml`. This is also added to CI.
* Modify cargo release profile

    This could make the generated shared library more efficient.
* Python CI

    Previous python CI always fails. I tried to fix it. At least now there is no typos in CI. However, it seems that the docker image that cibuildwheel uses does not support building Unicorn and cbindgen (seems like even the LLVM version is not updated enough). What about disable it and just use the maturin's CI anyway?
* Rust API

    The `always_validate` argument for `afl_fuzz` is useless, since users can only specify crash validators in `afl_fuzz_custom` API. This does not affect C API.