### PR TITLE
Add docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ At this moment, manual building is required (see below) but we will soon release
 
 ### C/C++
 
-After building this repo, you could link the generated shared library with included C/C++ header file in [include/unicornafl.h](./include/unicornafl.h).
+After building this repo, you could link the generated static archive or shared library with included C/C++ header file in [include/unicornafl.h](./include/unicornafl.h).
 
 ## Build
 
@@ -68,4 +68,4 @@ This shall find the crash instantly, thanks to the `cmplog` integration.
 
 ## Migration
 
-There should be nothing special migrating from unicornafl v2.x to unicornafl v3.x, execpt the way integrating with AFL++. If your harness builds and statically links against unicornafl directly, there is no longer needed for the unicorn mode with AFL++. However, for Python users with `libunicornafl.so` dynamically linked, unicorn mode (`-U` option) is still needed for `afl-fuzz` command line.
+There should be nothing special migrating from unicornafl v2.x to unicornafl v3.x, execpt the way integrating with AFL++. If your harness builds and statically links against unicornafl directly, there is no longer needed for the unicorn mode with AFL++. However, if you are using Python, or using C/C++ with `libunicornafl.so` dynamically linked, unicorn mode (`-U` option) is still needed for `afl-fuzz` command line.

--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ Starting from v3.0.0, unicornafl is fully rewritten with `libafl_targets` in Rus
 To use `unicornafl` as a library, just add this to your `Cargo.toml`
 
 ```toml
-unicornafl = {git = "https://github.com/AFLplusplus/unicornafl", branch = "main"}
+unicornafl = { git = "https://github.com/AFLplusplus/unicornafl", branch = "main" }
 ```
 
 `main` is used here because `unicorn` is not released yet. We will make it ready shortly.
@@ -19,6 +19,10 @@ unicornafl = {git = "https://github.com/AFLplusplus/unicornafl", branch = "main"
 ### Python
 
 At this moment, manual building is required (see below) but we will soon release wheels.
+
+### C/C++
+
+After building this repo, you could link the generated shared library with included C/C++ header file in [include/unicornafl.h](./include/unicornafl.h).
 
 ## Build
 
@@ -64,4 +68,4 @@ This shall find the crash instantly, thanks to the `cmplog` integration.
 
 ## Migration
 
-There should be nothing special migrating from unicornafl v2.x to unicornafl v3.x, execpt the way integrating with `AFL++`. If your harness builds and statically links against unicornafl directly, there is no longer needed for the unicorn mode with `AFL++`. However, for Python users with `libunicornafl.so` dynamically linked, unicorn mode is still needed for `AFL++` command line.
+There should be nothing special migrating from unicornafl v2.x to unicornafl v3.x, execpt the way integrating with AFL++. If your harness builds and statically links against unicornafl directly, there is no longer needed for the unicorn mode with AFL++. However, for Python users with `libunicornafl.so` dynamically linked, unicorn mode (`-U` option) is still needed for `afl-fuzz` command line.

--- a/Readme.md
+++ b/Readme.md
@@ -16,13 +16,19 @@ unicornafl = { git = "https://github.com/AFLplusplus/unicornafl", branch = "main
 
 `main` is used here because `unicorn` is not released yet. We will make it ready shortly.
 
+For more details, please refer to [Rust usage](./docs/rust-usage.md).
+
 ### Python
 
 At this moment, manual building is required (see below) but we will soon release wheels.
 
+For more details, please refer to [Python usage](./docs/python-usage.md).
+
 ### C/C++
 
 After building this repo, you could link the generated static archive or shared library with included C/C++ header file in [include/unicornafl.h](./include/unicornafl.h).
+
+For more details, please refer to [C/C++ usage](./docs/c-usage.md).
 
 ## Build
 
@@ -37,7 +43,7 @@ cargo build --release
 For python bindings, we have:
 
 ```bash
-maturin build
+maturin build --release
 ```
 
 ## Example && Minimal Tutorial
@@ -65,6 +71,8 @@ afl-fuzz -i ./input -o ./output-8 -b 1 -g 8 -G 8 -V 60 -c 0 -- ./target/release/
 ```
 
 This shall find the crash instantly, thanks to the `cmplog` integration.
+
+For more details, please refer to [Fuzzing using UnicornAFL](./docs/fuzzing.md).
 
 ## Migration
 

--- a/docs/c-usage.md
+++ b/docs/c-usage.md
@@ -1,0 +1,106 @@
+# C/C++ Usage for UnicornAFL
+
+To use UnicornAFL with C/C++, you should clone this repository and build it yourself:
+
+```shell
+git clone --depth 1 https://github.com/AFLplusplus/unicornafl && cd unicornafl
+cargo build --release
+```
+
+Before building this repo, make sure that you have installed dependencies to build [Unicorn](https://github.com/unicorn-engine/unicorn), and installed stable Rust compiler with at least 1.87.0.
+
+After building this repo, there will be a `libunicornafl.a` and a `libunicornafl.so` in `./target/release/` directory. To use UnicornAFL, you should link either one, and use header file at `./include/unicornafl.h`.
+
+## API usage
+
+The API for UnicornAFL is simple but powerful, which is the following two functions: `uc_afl_fuzz` and `uc_afl_fuzz_custom`.
+
+### Simplified API
+
+`uc_afl_fuzz`
+
+```c
+uc_afl_ret uc_afl_fuzz(uc_engine* uc, char* input_file,
+                       uc_afl_cb_place_input_t place_input_callback,
+                       uint64_t* exits, size_t exit_count,
+                       uc_afl_cb_validate_crash_t validate_crash_callback,
+                       bool always_validate, uint32_t persistent_iters,
+                       void* data);
+```
+
+`uc` is a unicorn instance created in advance. See the following [Creating Unicorn Instance](#Creating-Unicorn-Instance) for more details.
+
+`input_file` is a path to input file. If you are using the fuzzing mode, just pass `NULL` to this argument, and the input seed directory should be passed to `afl-fuzz` instead. For standalone mode, UnicornAFL takes input using this argument.
+
+`place_input_callback` is the callback for UnicornAFL to place received input into Unicorn's memory space. This callback takes five arguments: a pointer to the unicorn intance which users could use to read/write unicorn's emulated CPU/memory in this callback, a pointer to the input buffer, the input buffer length, the persistent round (which means how many times have this harness executed without exiting and forking to another child process), and custom data. This callback should return a bool, indicating whether this input is acceptable.
+
+`exits` and `exit_count` means the exit points for Unicorn. When the Unicorn instance reaches one of the given exit address, UnicornAFL will switch to next round.
+
+`validate_crash_callback` is the callback for UnicornAFL when an error encounted when executing the harness. It takes six arguments: a pointer to the unicorn intance, a value indicating the error of Unicorn when exuecting the harness, a pointer to the input buffer, the input buffer length, the persistent round, and custom data. This callback should return a bool, if it is `false`, then the AFL++ main executable will not treat this round as crash. This could be used to eliminate false positives during fuzzing.
+
+`always_validate` means whether the `validate_crash_callback` will be invoked even if the Unicorn does not face errors during execution.
+
+`persistent_iters` specifies how many times should this harness being executed persistently until the parent forks another child. For simplicity, you could just pass `1` here, which means always exiting and forking whenever this harness ends. However, if you want to write a more efficient harness, you should consider running persistently. Passing `0` here means never exiting or forking unless the process crashes, just run persistently.
+
+`data` is a custom data. In each callback listed above, this pointer will also passed as the callback argument. By this way you could maintain some shared data across execution.
+
+This function returns a `uc_afl_ret`. If it is not `UC_AFL_RET_OK`, this means unexpected things happened during fuzzing that you should take care of.
+
+### Advanced API
+
+`uc_afl_fuzz_custom`
+
+```c
+uc_afl_ret uc_afl_fuzz_custom(uc_engine* uc, char* input_file,
+                              uc_afl_cb_place_input_t place_input_callback,
+                              uc_afl_fuzz_cb_t fuzz_callbck,
+                              uc_afl_cb_validate_crash_t validate_crash_callback,
+                              bool always_validate, uint32_t persistent_iters,
+                              void* data);
+```
+
+Some of the arguments are the same as the simplified API. The only difference is the `fuzz_callbck` argument. UnicornAFL will use this function to start one execution round, and when this function stops, UnicornAFL knows this round has ended. By default, UnicornAFL will just use `uc_emu_start()`.
+
+### Creating Unicorn Instance
+
+Before using fuzzing APIs, you should create unicorn instance on your own. It should be noted that, UnicornAFL does not need to know the actual target to fuzz. Instead, you should manually setup your target in Unicorn instance (for example, map the codes in unicorn's memory space).
+
+## Tips
+
+### Linking
+
+Note that `libunicornafl.a` or `libunicornafl.so` already bundles a Unicorn. As a result, you don't need to manually link Unicorn any more.
+
+### Use a different version of Unicorn
+
+It should be noted that the internal of UnicornAFL depends heavily on some newest Unicorn APIs. As a result, older version of Unicorn may not work. However, if you want to use your own version of Unicorn, you should modify the `Cargo.toml` in this repo.
+
+First, find the following line:
+
+```toml
+unicorn-engine = { git = "https://github.com/unicorn-engine/unicorn", branch = "dev" }
+```
+
+If you want to use a Unicorn in local filesystem, you should change this line to
+
+```toml
+unicorn-engine = { path = "/path/to/unicorn/bindings/rust" }
+```
+
+Note that the `bindings/rust` suffix is necessary.
+
+If you want to use a forked Unicorn or Unicorn in remote Git server, you should change this line to
+
+```toml
+unicorn-engine = { git = "http://my/own/unicorn/fork" }
+```
+
+### Debugging
+
+Inside UnicornAFL, there are many logs could be used for debugging. To enable logging, you should compile this repo using
+
+```shell
+cargo build --release --features env_logger
+```
+
+And when running, passing `RUST_LOG=trace` as environment. (`AFL_DEBUG=1` is also needed if you are using `afl-fuzz` to run the harness)

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -1,0 +1,70 @@
+# Fuzzing using UnicornAFL
+
+UnicornAFL is a bridge between AFL++ and Unicorn. 
+
+## Running Mode
+
+The harness built with UnicornAFL supports two running mode: standalone mode and fuzzing mode.
+
+### Standalone Mode
+
+This mode is not intended for fuzzing. Instead, you should use this mode to check whether you have written the correct harness, and it is also helpful to analyze the crashes found by AFL++.
+
+To run harness in standalone mode, you should directly execute the harness executable that uses UnicornAFL without using `afl-fuzz`. The commandline options for executing this harness is defined by users. Users need to then pass correct value to the parameter of UnicornAFL API, especially the `input_file` argument. The commandline harness executable should take a path to a file, then if it is passed to the `input_file`, UnicornAFL will use that file as input to execute the Unicorn engine for the target being tested.
+
+Before any fuzzing, you should create a normal input seed that don't expect to crash the harness. Then you should run in standalone mode to check that the harness can execute normally. Then if anything unexpected happened during standalone mode, this means you write the wrong harness.
+
+### Fuzzing mode
+
+After testing the correctness of the harness, then you can fuzz the harness using `afl-fuzz`. To use `afl-fuzz` with UnicornAFL, you should first make sure how you build the harness.
+
+If you are using Rust, or if you are using C/C++ that statically link the `libunicornafl.a`, then the minimized working example is
+
+```shell
+afl-fuzz \
+    -i input \
+    -o output \
+    -- \
+    ./your-harness --and-your-own-harness-options
+```
+
+If you are using Python, or if you are using C/C++ that dynamically link the `libunicornafl.so`, then the minimized working example is
+
+```shell
+afl-fuzz \
+    -U \
+    -i input \
+    -o output \
+    -- \
+    ./your-harness --and-your-own-harness-options
+```
+
+The `-U` option specifies that this is the legacy Unicorn mode.
+
+Note that you don't need to use `@@` to specify input file, we use shared memory to get input seed.
+
+## Persistent Fuzzing
+
+UnicornAFL supports persistent fuzzing. Instead of forking at the beginning of each execution round, persistent fuzzing will just do a `for`-loop to execute the target. The overall steps are:
+
+1. Users invoke `afl-fuzz` and pass the path to your UnicornAFL harness.
+2. `afl-fuzz` spawns a harness process (which we call it harness parent).
+3. The harness process will execute until the beginning of one of the UnicornAFL's APIs (`uc_afl_fuzz` and `uc_afl_fuzz_custom`). Then it will fork itself, producing another process (which we call it harness child).
+4. The harness child contains a loop that executes the target with Unicorn engine repeatly. Each round is counted as a execution for `afl-fuzz`.
+5. When the user specified `persistent_round` is achieved, or the harness child process crashes (which is rare, since the exceptions shall be captured by Unicorns already), the harness child end. The harness parent will fork a new harness child and do the same thing.
+
+Since in the harness child, the target is executed repeatly, it is very important that **you should restore the Unicorn's state after each round** unless you can make sure the target does not modify Unicorn's CPU and memory in this round. To make things easier, you can just specify `persistent_round` as 1, which downgrade to the legacy forkserver-based fuzzing, which is significantly slower.
+
+## CMPLOG and CMPCOV
+
+UnicornAFL also supprost CMPLOG and CMPCOV in AFL++. If you don't know these terms, please refer to the AFL++'s documentation. In short, this is aimed to bypass the long comparison like `CMP RAX, 0x114514`.
+
+To use CMPCOV mode, you should specify `UNICORN_AFL_CMPCOV=1` environment in `afl-fuzz`.
+
+To use CMPLOG mode, you can just add `-c 0` option to `afl-fuzz`.
+
+## Which language should I choose to use?
+
+The language to choose may have a little affect on the throughput of fuzzing, while you should keep in mind that the main overhead is the target itself.
+
+Although not benchmarked, Rust may be a slightly faster than C/C++ due to the power of inlining and LTO. The python version is much more slower. However, since the it only have a little affect, it is more appropriate if you choose the language that you are good at. Don't struggle with language itself, it is fuzzing that is all you need :)

--- a/docs/python-usage.md
+++ b/docs/python-usage.md
@@ -96,6 +96,12 @@ If you want to use a forked Unicorn or Unicorn in remote Git server, you should 
 unicorn-engine = { git = "http://my/own/unicorn/fork" }
 ```
 
+### Linking
+
+To use UnicornAFL and Unicorn at the same time, you should make sure that the Unicorn version that UnicornAFL uses is consistent with the Unicorn version of Unicorn Python package. Then you can import Unicorn package and UnicornAFL package at the same time.
+
+When building the Python binding, we dynamically link the Unicorn shared library. As a result, using UnicornAFL and Unicorn package at the same time will be OK as long as the Unicorn version does not conflict.
+
 ### Debugging
 
 Inside UnicornAFL, there are many logs could be used for debugging. To enable logging, you should compile this repo using

--- a/docs/python-usage.md
+++ b/docs/python-usage.md
@@ -1,0 +1,107 @@
+# Python Usage for UnicornAFL
+
+To use UnicornAFL with Python, you should clone this repository and build it yourself:
+
+```shell
+git clone --depth 1 https://github.com/AFLplusplus/unicornafl && cd unicornafl
+cargo build --release
+maturin build --release
+```
+
+Before building this repo, make sure that you have installed dependencies to build [Unicorn](https://github.com/unicorn-engine/unicorn), and installed stable Rust compiler with at least 1.87.0, and you should also install [maturin](https://www.maturin.rs).
+
+After building this repo, there will be a wheel in `./target/wheels`, just use it.
+
+## API usage
+
+The API for UnicornAFL is simple but powerful, which is the following two functions: `uc_afl_fuzz` and `uc_afl_fuzz_custom`.
+
+### Simplified API
+
+`uc_afl_fuzz`
+
+```python
+def uc_afl_fuzz(uc: Uc,
+                input_file: str,
+                place_input_callback: Callable,
+                exits: List[int],
+                validate_crash_callback: Callable = None,
+                always_validate: bool = False,
+                persistent_iters: int = 1,
+                data: Any = None): ...
+```
+
+`uc` is a unicorn instance created in advance. See the following [Creating Unicorn Instance](#Creating-Unicorn-Instance) for more details.
+
+`input_file` is a path to input file. If you are using the fuzzing mode, just pass `None` to this argument, and the input seed directory should be passed to `afl-fuzz` instead. For standalone mode, UnicornAFL takes input using this argument.
+
+`place_input_callback` is the callback for UnicornAFL to place received input into Unicorn's memory space. This callback takes four arguments: a pointer to the unicorn intance which users could use to read/write unicorn's emulated CPU/memory in this callback, input buffer, the persistent round (which means how many times have this harness executed without exiting and forking to another child process), and custom data. This callback should return a Bool, indicating whether this input is acceptable.
+
+`exits` means the exit points for Unicorn. When the Unicorn instance reaches one of the given exit address, UnicornAFL will switch to next round.
+
+`validate_crash_callback` is the callback for UnicornAFL when an error encounted when executing the harness. It takes five arguments: a pointer to the unicorn intance, a value indicating the error of Unicorn when exuecting the harness, the input buffer, the persistent round, and custom data. This callback should return a Bool, if it is `False`, then the AFL++ main executable will not treat this round as crash. This could be used to eliminate false positives during fuzzing.
+
+`always_validate` means whether the `validate_crash_callback` will be invoked even if the Unicorn does not face errors during execution.
+
+`persistent_iters` specifies how many times should this harness being executed persistently until the parent forks another child. For simplicity, you could just pass `1` here, which means always exiting and forking whenever this harness ends. However, if you want to write a more efficient harness, you should consider running persistently. Passing `0` here means never exiting or forking unless the process crashes, just run persistently.
+
+`data` is a custom data. In each callback listed above, this pointer will also passed as the callback argument. By this way you could maintain some shared data across execution.
+
+This function returns a `UcAflError` or value `UC_AFL_RET_OK`. If the return value is not `UC_AFL_RET_OK`, this means unexpected things happened during fuzzing that you should take care of.
+
+### Advanced API
+
+`uc_afl_fuzz_custom`
+
+```python
+def uc_afl_fuzz_custom(uc: Uc,
+                       input_file: str,
+                       place_input_callback: Callable,
+                       fuzzing_callback: Callable,
+                       validate_crash_callback: Callable = None,
+                       always_validate: bool = False,
+                       persistent_iters: int = 1,
+                       data: Any = None): ...
+```
+
+Some of the arguments are the same as the simplified API. The only difference is the `fuzz_callbck` argument. UnicornAFL will use this function to start one execution round, and when this function stops, UnicornAFL knows this round has ended. By default, UnicornAFL will just use `uc_emu_start()`.
+
+### Creating Unicorn Instance
+
+Before using fuzzing APIs, you should create unicorn instance on your own. It should be noted that, UnicornAFL does not need to know the actual target to fuzz. Instead, you should manually setup your target in Unicorn instance (for example, map the codes in unicorn's memory space).
+
+## Tips
+
+### Use a different version of Unicorn
+
+It should be noted that the internal of UnicornAFL depends heavily on some newest Unicorn APIs. As a result, older version of Unicorn may not work. However, if you want to use your own version of Unicorn, you should modify the `Cargo.toml` in this repo.
+
+First, find the following line:
+
+```toml
+unicorn-engine = { git = "https://github.com/unicorn-engine/unicorn", branch = "dev" }
+```
+
+If you want to use a Unicorn in local filesystem, you should change this line to
+
+```toml
+unicorn-engine = { path = "/path/to/unicorn/bindings/rust" }
+```
+
+Note that the `bindings/rust` suffix is necessary.
+
+If you want to use a forked Unicorn or Unicorn in remote Git server, you should change this line to
+
+```toml
+unicorn-engine = { git = "http://my/own/unicorn/fork" }
+```
+
+### Debugging
+
+Inside UnicornAFL, there are many logs could be used for debugging. To enable logging, you should compile this repo using
+
+```shell
+cargo build --release --features env_logger
+```
+
+And when running, passing `RUST_LOG=trace` as environment. (`AFL_DEBUG=1` is also needed if you are using `afl-fuzz` to run the harness)

--- a/docs/rust-usage.md
+++ b/docs/rust-usage.md
@@ -22,7 +22,6 @@ fn afl_fuzz<'a, D: 'a>(
     input_file: Option<PathBuf>,
     place_input_cb: impl FnMut(&mut Unicorn<'a, UnicornFuzzData<D>>, &[u8], u64) -> bool + 'a,
     exits: Vec<u64>,
-    always_validate: bool,
     persistent_iters: Option<u64>,
 ) -> Result<(), uc_afl_ret>;
 ```
@@ -33,13 +32,37 @@ Please don't be scared by the lifetime mark in function signature. In most time,
 
 `input_file` is a path to input file. If you are using the fuzzing mode, just pass `None` to this argument, and the input seed directory should be passed to `afl-fuzz` instead. For standalone mode, UnicornAFL takes input using this argument.
 
-`place_input_cb` is the callback for UnicornAFL to place received input into Unicorn's memory space. This closure takes three arguments: a mutable reference to the unicorn intance, a reference to the input buffer, the persistent round (which means how many times have this harness executed without exiting and forking to another child process). This closure should return a bool, indicating whether this input is acceptable.
+`place_input_cb` is the callback for UnicornAFL to place received input into Unicorn's memory space. This closure takes three arguments: a mutable reference to the unicorn intance which users could use to read/write unicorn's emulated CPU/memory in this callback, a reference to the input buffer, the persistent round (which means how many times have this harness executed without exiting and forking to another child process). This closure should return a bool, indicating whether this input is acceptable.
 
 `exits` means the exit points for Unicorn. When the Unicorn instance reaches one of the given exit address, UnicornAFL will switch to next round.
 
-`always_validate`
+`persistent_iters` specifies how many times should this harness being executed persistently until the parent forks another child. For simplicity, you could just pass `Some(1)` here, which means always exiting and forking whenever this harness ends. However, if you want to write a more efficient harness, you should consider running persistently. Passing `None` here means never exiting or forking unless the process crashes, just run persistently.
+
+This function returns a `Result`. If it is an `Err`, this means unexpected things happened during fuzzing that you should take care of.
+
+To use this API, you could write code like this:
+
+```rust
+// Creating uc
+// Other setup ...
+
+if let Err(err) = unicornafl::afl_fuzz(
+    uc,
+    None,
+    |uc, input, persistent_round| {
+        // Custom logics here, use uc.reg_write() or uc.mem_write(), for instance.
+        true
+    },
+    vec![0x4001000, 0x4002000],
+    Some(1),
+) {
+    eprintln!("Unexpected happened! {err:?}");
+}
+```
 
 ### Advanced API
+
+`unicornafl::afl_fuzz_custom`
 
 ```rust
 fn afl_fuzz_custom<'a, D: 'a>(
@@ -52,8 +75,144 @@ fn afl_fuzz_custom<'a, D: 'a>(
 ) -> Result<(), uc_afl_ret>;
 ```
 
+Some of the arguments are the same as the simplified API. The only difference is `callbacks` and `always_validate`.
+
+`callbacks` is a structure that users should define and implement on their own. The definition of `UnicornAflExecutorHook` is in [executor.rs](../src/executor.rs), which is well-documented that you should look at first.
+
+There are three methods in `UnicornAflExecutorHook`:
+
+* `place_input`
+
+    This is required to implement. The meaning of this method is the same as `place_input_cb` in simplified API.
+* `validate_crash`
+
+    This is optional to implement. This will be invoked if Unicorn encounters exceptions when executing the harness, or users specify `always_validate` to be true. This could be used to eliminate false positives during fuzzing. If this function returns `false`, then the AFL++ main executable will not treat this round as crash.
+* `fuzz`
+
+    This is optional to implement. UnicornAFL will use this function to start one execution round, and when this function stops, UnicornAFL knows this round has ended. By default, UnicornAFL will just use `uc.emu_start()`.
+
+Note that all these three methods take `&mut self` as input. This means if there are some data shared across persistent rounds and are used by these callbacks, you could store it in the structure. However, you should be noted that when the max persistent round is reached (which you specified in `persistent_round` argument), current process will exit and the parent will fork a new one whose initial state is just before the invoking of `afl_fuzz_custom`. As a result, you should save your data after `afl_fuzz_custom` ends, and read last round's data before `afl_fuzz_custom`.
+
+To use this API, you could write code like this:
+
+```rust
+use unicornafl::UnicornAflExecutorHook;
+
+struct MyOwnExecutorHook {
+    my_data: usize
+}
+
+impl UnicornAflExecutorHook for MyOwnExecutorHook {
+    fn place_input(
+        &mut self,
+        uc: &mut Unicorn<'a, UnicornFuzzData<D>>,
+        input: &[u8],
+        persistent_round: u64,
+    ) -> bool {
+        // Custom logics here, use uc.reg_write() or uc.mem_write(), for instance.
+        true
+    }
+
+    // I don't need to implement `validate_crash` and `fuzz`.
+}
+
+fn main() {
+    // Creating uc
+    // Other setup ...
+
+    if let Err(err) = unicornafl::afl_fuzz_custom(
+        uc,
+        None,
+        MyOwnExecutorHook { my_data: 0 },
+        vec![0x4001000, 0x4002000],
+        false,
+        Some(1),
+    ) {
+        eprintln!("Unexpected happened! {err:?}");
+    }
+}
+```
+
 ### Creating Unicorn Instance
+
+Before using fuzzing APIs, you should create unicorn instance on your own. It should be noted that, UnicornAFL does not need to know the actual target to fuzz. Instead, you should manually setup your target in Unicorn instance (for example, map the codes in unicorn's memory space). To create a Unicorn instance used for UnicornAFL for fuzzing, you should do things like:
+
+```rust
+use unicornafl::UnicornFuzzData;
+
+// Set up arch, mode, and some shared fuzzing data.
+let mut uc = Unicorn::new_with_data(Arch::X86, Mode::MODE_64, UnicornFuzzData::default());
+```
+
+`UnicornFuzzData` is a helper for maintaining shared data during execution. In general, there are two kinds of data to share when using UnicornAFL: 1. Data that need to be shared during persistent execution, and is only used in `UnicornAflExecutorHook`'s callbacks, which means these data are only used **before** or **after** one execution round. 2. Data that need to be shared during one execution round, and is used in multiple hooks of Unicorn (code hooks, memory hooks, etc.). The former data should be stored in the structure that implements `UnicornAflExecutorHook`, and the latter one is hat `UnicornFuzzData` is used for.
+
+In fact, `UnicornFuzzData` is a wrapper over arbitrary generic structure, which you could define your own data. Inside Unicorn's hooks, users could use `get_data()` or `get_data_mut()` to access the `UnicornFuzzData` structure, which can be further used to access user-defined data using `.user_data` field.
+
+For example:
+
+```rust
+use unicornafl::UnicornFuzzData;
+
+struct MyFuzzData {
+    hook_call_count: usize
+}
+
+let mut uc = Unicorn::new_with_data(
+    Arch::X86,
+    Mode::MODE_64,
+    UnicornFuzzData::new(
+        MyFuzzData {
+            hook_call_count: 0
+        }
+    )
+);
+
+uc.add_code_hook(/* ... */, |uc, _, _| {
+    let my_fuzz_data = &mut uc.get_data_mut().user_data;
+    my_fuzz_data.hook_call_count += 1;
+}).unwrap();
+```
+
+However, you should note that the `get_data` or `get_data_mut` would require `Rc` check, which may potentially decrease the performance. As a result, you should minimize such data accesses.
 
 ## Tips
 
+### Build release version
 
+In Rust, the default profile used for `cargo build` is debug build, which is slow. To optimize fuzzing throughput, you should use release profile by `cargo build --release`. Moreover, inside your `Cargo.toml`, it is suggested to add
+
+```toml
+[profile.release]
+lto = true
+codegen-units = 1
+```
+
+This may significantly increase compile time, but the generated binary is very optimized.
+
+### Use a different version of Unicorn
+
+It should be noted that the internal of UnicornAFL depends heavily on some newest Unicorn APIs. As a result, older version of Unicorn may not work. However, if you want to use your own version of Unicorn, you should modify your `Cargo.toml`, add the following blocks:
+
+```toml
+[patch.'https://github.com/unicorn-engine/unicorn']
+unicorn-engine = { path = "/my/own/path/to/local/unicorn" }
+# or
+unicorn-engine = { git = "http://my/own/unicorn/fork" }
+```
+
+For more, see [Overriding Dependencies](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html).
+
+### Debugging
+
+Inside UnicornAFL, there are many logs could be used for debugging. To enable logging, the easiest way is to add dependency for [env_logger](https://crates.io/crates/env_logger), and at the beginning of your `main` function:
+
+```rust
+fn main() {
+    env_logger::init();
+    // ...
+}
+```
+
+And when running, passing `RUST_LOG=trace` as environment. (`AFL_DEBUG=1` is also needed if you are using `afl-fuzz` to run the harness)
+
+The logging in UnicornAFL utilizes the [log crate](https://crates.io/crates/log), which supports various type of logging backend. If you want to customize the logging behavior, you are suggested to read that crate's document. `env_logger` also supports many customizations. For example, if you only want to see your own logs, and don't want to see logs from UnicornAFL, you could use environment variable `RUST_LOG=trace,unicornafl=off`.

--- a/docs/rust-usage.md
+++ b/docs/rust-usage.md
@@ -1,0 +1,59 @@
+# Rust Usage for UnicornAFL
+
+To use UnicornAFL with Rust, you should create a new Rust package, and add the following line into the `[dependencies]` section in `Cargo.toml`:
+
+```toml
+unicornafl = { git = "https://github.com/AFLplusplus/unicornafl", branch = "main" }
+```
+
+Before building the new package, make sure that you have installed dependencies to build [Unicorn](https://github.com/unicorn-engine/unicorn).
+
+## API usage
+
+After declaring UnicornAFL as a dependency, you could now write your own fuzzing harness. The API for UnicornAFL is simple but powerful, which is the following two functions: `afl_fuzz` and `afl_fuzz_custom`.
+
+### Simplified API
+
+`unicornafl::afl_fuzz`
+
+```rust
+fn afl_fuzz<'a, D: 'a>(
+    uc: Unicorn<'a, UnicornFuzzData<D>>,
+    input_file: Option<PathBuf>,
+    place_input_cb: impl FnMut(&mut Unicorn<'a, UnicornFuzzData<D>>, &[u8], u64) -> bool + 'a,
+    exits: Vec<u64>,
+    always_validate: bool,
+    persistent_iters: Option<u64>,
+) -> Result<(), uc_afl_ret>;
+```
+
+Please don't be scared by the lifetime mark in function signature. In most time, you don't need to care about that.
+
+`uc` is a unicorn instance created in advance. See the following [Creating Unicorn Instance](#Creating-Unicorn-Instance) for more details.
+
+`input_file` is a path to input file. If you are using the fuzzing mode, just pass `None` to this argument, and the input seed directory should be passed to `afl-fuzz` instead. For standalone mode, UnicornAFL takes input using this argument.
+
+`place_input_cb` is the callback for UnicornAFL to place received input into Unicorn's memory space. This closure takes three arguments: a mutable reference to the unicorn intance, a reference to the input buffer, the persistent round (which means how many times have this harness executed without exiting and forking to another child process). This closure should return a bool, indicating whether this input is acceptable.
+
+`exits` means the exit points for Unicorn. When the Unicorn instance reaches one of the given exit address, UnicornAFL will switch to next round.
+
+`always_validate`
+
+### Advanced API
+
+```rust
+fn afl_fuzz_custom<'a, D: 'a>(
+    uc: Unicorn<'a, UnicornFuzzData<D>>,
+    input_file: Option<PathBuf>,
+    callbacks: impl UnicornAflExecutorHook<'a, D>,
+    exits: Vec<u64>,
+    always_validate: bool,
+    persistent_iters: Option<u64>,
+) -> Result<(), uc_afl_ret>;
+```
+
+### Creating Unicorn Instance
+
+## Tips
+
+


### PR DESCRIPTION
This PR and #46 are separate, you could review and merge these two PR independently without any conflict :)

When writing the docs, I realize that there is something we should do in Python binding. Should the python user use Unicorn package and UnicornAFL at the same time? If so, how to solve the linking problem? If not, how does UnicornAFL package provide interfaces for Unicorn engine?